### PR TITLE
added x86_64 & arm Dockerfiles

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,36 @@
+FROM ubuntu:18.04
+
+# Adding rust binaries to PATH.
+ENV PATH="$PATH:/root/.cargo/bin"
+
+RUN apt update
+
+RUN apt-get -y install gcc
+
+# Installing rustup.
+RUN apt-get -y install curl
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Installing rust tools used by the rust-vmm CI.
+RUN rustup component add rustfmt
+# clippy is not yet supported in stable rust for aarch64.
+# Should be available starting with 12 April 2019.
+# RUN rustup component add clippy
+RUN cargo install cargo-kcov
+
+# Installing other rust targets.
+RUN rustup target add aarch64-unknown-linux-musl
+
+# Installing kcov dependencies.
+RUN apt-get -y install cmake g++ pkg-config jq
+RUN apt-get -y install libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
+
+# Installing kcov.
+# For some strange reason, the command requires python to be installed
+RUN apt-get -y install python
+RUN cargo kcov --print-install-kcov-sh | sh
+
+# Installing python3.6 & pytest.
+RUN apt-get -y install python3.6
+RUN apt-get -y install python3-pip
+RUN pip3 install pytest

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04
+
+# Adding rust binaries to PATH.
+ENV PATH="$PATH:/root/.cargo/bin"
+
+RUN apt-get update
+
+RUN apt-get -y install gcc
+
+# Installing rustup.
+RUN apt-get -y install curl
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Installing rust tools used by the rust-vmm CI.
+RUN rustup component add rustfmt
+RUN rustup component add clippy
+RUN cargo install cargo-kcov
+
+# Installing other rust targets.
+RUN rustup target add x86_64-unknown-linux-musl
+
+# Installing kcov dependencies.
+RUN apt-get -y install cmake g++ pkg-config jq
+RUN apt-get -y install libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
+
+# Installing kcov.
+# For some strange reason, the command requires python to be installed
+RUN apt-get -y install python
+RUN cargo kcov --print-install-kcov-sh | sh
+
+# Installing python3.6 & pytest.
+RUN apt-get -y install python3.6
+RUN apt-get -y install python3-pip
+RUN pip3 install pytest

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
-# rust-vmm-container
-Container with all dependencies required for running rust-vmm crates integration tests. 
+# rust-vmm-dev-container
+
+**rust-vmm-dev** is a container with all dependencies used for running
+rust-vmm integration tests.
+
+The container is available on Docker Hub and has support for x86_64 and
+aarch64 platforms.
+Pull the latest version by running:
+
+```bash
+docker pull fandree/rust-vmm-dev
+```
+
+Depending on which platform you're running the command from, docker will pull
+either `rust-vmm-dev:aarch64` or `rust-vmm-dev:x86_64`.
+
+For now rust is installed only for the root user.
+
+### Using the Container
+
+The container is currently used for running the integration tests for the
+[kvm-ioctls](https://github.com/rust-vmm/kvm-ioctls) crate.
+
+Example of running cargo build on the kvm-ioctls crate:
+
+```bash
+> git clone git@github.com:rust-vmm/kvm-ioctls.git
+> cd kvm-ioctls/
+> docker run --volume $(pwd):/kvm-ioctls \
+         fandree/rust-vmm-dev \
+         /bin/bash -c "cd /kvm-ioctls && cargo build --release"
+ Downloading crates ...
+  Downloaded libc v0.2.48
+  Downloaded kvm-bindings v0.1.1
+   Compiling libc v0.2.48
+   Compiling kvm-bindings v0.1.1
+   Compiling kvm-ioctls v0.0.1 (/kvm-ioctls)
+    Finished release [optimized] target(s) in 5.63s
+```
+
+### Available Tools
+
+The container currently has the Rust toolchain version 1.33.0 and Python3.6.
+
+Python packages:
+- [pip3](https://pip.pypa.io/en/stable/)
+- [pytest](https://docs.pytest.org/en/latest/)
+
+Cargo plugins:
+- [rustfmt](https://github.com/rust-lang/rustfmt)
+- [cargo-kcov](https://github.com/kennytm/cargo-kcov)
+- [clippy](https://github.com/rust-lang/rust-clippy) - only available on
+  x86_64. For details check this issue:
+  https://github.com/rust-lang/rust-clippy/issues/3682
+
+Rust targets on x86_64:
+- x86_64-unknown-linux-gnu
+- x86_64-unknown-linux-musl
+
+Rust targets on aarch64:
+- aarch64-unknown-linux-gnu
+- aarch64-unknown-linux-musl
+
+### Publishing a New Version
+
+On an aarch64 platform:
+
+```bash
+> cd rust-vmm-dev-container
+> # Build a container image for aarch64
+> docker build -t rust-vmm-dev:aarch64 -f Dockerfile.aarch64 .
+> docker images
+REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
+fandree/rust-vmm-dev   aarch64             f3fd02dfb213        21 hours ago        1.13GB
+fandree/rust-vmm-dev   latest              f3fd02dfb213        21 hours ago        1.13GB
+ubuntu                 18.04               0926e73e5245        3 weeks ago         80.4MB
+>
+> docker tag f3fd02dfb213 fandree/rust-vmm-dev:aarch64
+> docker push fandree/rust-vmm-dev
+```
+
+You will need to redo all steps on a x86_64 platform so the containers are kept
+in sync (same package versions on both x86_64 and aarch64).
+
+```bash
+> docker build -t rust-vmm-dev:x86_64 -f Dockerfile.x86_64 .
+> docker tag XXXXXXXX fandree/rust-vmm-dev:x86_64
+> docker push fandree/rust-vmm-dev
+```
+
+Now that new versions of the tags `x86_64` and `aarch64` are pushed to Docker
+Hub, we can go ahead and also update the latest tag using
+[docker manifest](https://docs.docker.com/engine/reference/commandline/manifest/).
+
+```bash
+docker manifest create \
+        fandree/rust-vmm-dev:latest \
+        fandree/rust-vmm-dev:x86_64 \
+        fandree/rust-vmm-dev:aarch64
+docker manifest push fandree/rust-vmm-dev:latest
+```
+
+If it is the first time you are creating a docker manifest, most likely it will
+fail with: ```docker manifest is only supported when experimental cli features
+are enabled```. Checkout
+[this article](https://medium.com/@mauridb/docker-multi-architecture-images-365a44c26be6)
+to understand why and how to fix it.


### PR DESCRIPTION
This container is used for running the rust-vmm CI. It only works on Linux.
It is currently hosted on Docker Hub under fandree/rust-vmm-dev.

The container image is build using docker manifest so that the latest
tag points to Dockerfile.x86_64 or Dockerfile.arm depending on the
platform.