### PR TITLE
Install fixed version of rust

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+ARG RUST_TOOLCHAIN="1.33.0"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
@@ -9,7 +10,8 @@ RUN apt-get -y install gcc
 
 # Installing rustup.
 RUN apt-get -y install curl
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+# Install a fixed version of rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
 
 # Installing rust tools used by the rust-vmm CI.
 RUN rustup component add rustfmt

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+ARG RUST_TOOLCHAIN="1.33.0"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
@@ -9,7 +10,8 @@ RUN apt-get -y install gcc
 
 # Installing rustup.
 RUN apt-get -y install curl
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+# Install a fixed version of rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
 
 # Installing rust tools used by the rust-vmm CI.
 RUN rustup component add rustfmt


### PR DESCRIPTION
We were previously installing the latest available Rust version
with each container build. In order to have reproducible builds,
the Rust version needs to be fixed and manually updated. This will
ensure that we don't have builds on master fail for the various
crates that already use this container that are due to a change
in the compiler.

Fixes: https://github.com/rust-vmm/rust-vmm-container/issues/5