### PR TITLE
rpm2cpio: Install this tool to extract bzImage from rpm

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -8,6 +8,9 @@ RUN apt-get update
 
 RUN apt-get -y install gcc
 
+# Install to extract bzImage 
+RUN apt-get -y rpm2cpio
+
 # Installing rustup.
 RUN apt-get -y install curl
 # Install a fixed version of rust


### PR DESCRIPTION
Signed-off-by: Cathy Zhang <cathy.zhang@intel.com>