### PR TITLE
Prepare for rustvmm/dev:v2

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG RUST_TOOLCHAIN="1.33.0"
+ARG RUST_TOOLCHAIN="1.34.0"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
@@ -15,9 +15,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOL
 
 # Installing rust tools used by the rust-vmm CI.
 RUN rustup component add rustfmt
-# clippy is not yet supported in stable rust for aarch64.
-# Should be available starting with 12 April 2019.
-# RUN rustup component add clippy
+RUN rustup component add clippy
 RUN cargo install cargo-kcov
 
 # Installing other rust targets.

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG RUST_TOOLCHAIN="1.33.0"
+ARG RUST_TOOLCHAIN="1.34.0"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example of running cargo build on the kvm-ioctls crate:
 
 ### Available Tools
 
-The container currently has the Rust toolchain version 1.33.0 and Python3.6.
+The container currently has the Rust toolchain version 1.34.0 and Python3.6.
 
 Python packages:
 - [pip3](https://pip.pypa.io/en/stable/)


### PR DESCRIPTION
Update rust version from 1.33 to 1.34. In Rust 1.34 clippy is
available on aarch64 as well.

Fixes: https://github.com/rust-vmm/rust-vmm-container/issues/9