### PR TITLE
Dockerfile: Only install clippy and rustfmt for x86_64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get -y install curl
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
 
 # Installing rust tools used by the rust-vmm CI.
-RUN rustup component add rustfmt
-RUN rustup component add clippy
+RUN if [ $(uname -m) = "x86_64" ]; then rustup component add rustfmt; fi
+RUN if [ $(uname -m) = "x86_64" ]; then rustup component add clippy; fi
 RUN cargo install cargo-kcov
 
 # Installing other rust targets.


### PR DESCRIPTION
aarch64 (glibc and musl) is a tier-2 Rust architecture, and not all
components are always available for it. In particular, rustfmt and
clippy seems to be missing for 1.37, 1.38 and 1.39.

This change installs clippy and rustfmt only on the x86_64 toolchains.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>