### PR TITLE
Update Rust toolchain to 1.43.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG RUST_TOOLCHAIN="1.39.0"
+ARG RUST_TOOLCHAIN="1.43.1"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"


### PR DESCRIPTION
See https://github.com/firecracker-microvm/firecracker/pull/1908

After this someone on the rust-vmm team should publish the new image to Docker Hub, so we can continue the work on the linked pull request.