### PR TITLE
add cpio and bc to the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,6 @@ RUN apt-get -y install libssl-dev
 # The latest cargo audit needs some Rust features that are unstable in 1.44.1.
 RUN cargo install cargo-audit --vers 0.11.2
 RUN cargo install cargo-license
+
+# Install cpio and bc, to build kernels.
+RUN apt-get -y install cpio bc


### PR DESCRIPTION
Both tools are useful when building kernels, necessary to test linux-loader/reference VMM facilities.
