### PR TITLE
install rust nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get -y install gcc
 RUN apt-get -y install curl
 # Install a fixed version of rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
+# Install the nightly so that we can run cargo fmt on code examples.
+RUN rustup toolchain install nightly
 
 # Installing rust tools used by the rust-vmm CI.
 RUN if [ $(uname -m) = "x86_64" ]; then rustup component add rustfmt; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG RUST_TOOLCHAIN="1.44.1"
+ARG RUST_TOOLCHAIN="1.49"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
@@ -24,6 +24,7 @@ RUN cargo install cargo-kcov
 RUN rustup target add $(uname -m)-unknown-linux-musl
 
 # Installing kcov dependencies.
+RUN apt-get -y install libssl-dev
 RUN apt-get -y install cmake g++ pkg-config jq
 RUN apt-get -y install libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
 


### PR DESCRIPTION
This is needed for running `cargo fmt` on code examples.