### PR TITLE
Bump Windows rust version

### DIFF
--- a/Dockerfile.windows.x86_64
+++ b/Dockerfile.windows.x86_64
@@ -5,7 +5,7 @@ ARG WIN_VER="ltsc2019"
 FROM mcr.microsoft.com/windows/servercore:$WIN_VER
 
 ENV chocolateyUseWindowsCompression "true"
-ENV RUST_TOOLCHAIN="1.39.0"
+ENV RUST_TOOLCHAIN="1.46.0"
 
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 ADD https://win.rustup.rs/x86_64 C:\TEMP\rustup-init.exe


### PR DESCRIPTION
The Windows docker file is using Rust 1.39. We're going to bump
the version to 1.49, which is used by the Linux container.