### PR TITLE
Adds a docker.sh build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
-ARG RUST_TOOLCHAIN="1.46"
+ARG RUST_TOOLCHAIN
+ARG GIT_COMMIT
+ARG GIT_BRANCH
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
@@ -59,3 +61,5 @@ RUN apt-get -y install debootstrap
 
 # Install shell check
 RUN apt-get -y --no-install-recommends install shellcheck
+
+RUN echo "{\"rev\":\"$GIT_COMMIT\",\"branch\":\"${GIT_BRANCH}\"}" > /buildinfo.json

--- a/Dockerfile.windows.x86_64
+++ b/Dockerfile.windows.x86_64
@@ -1,6 +1,8 @@
 # escape=`
-
 ARG WIN_VER="ltsc2019"
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG RUST_TOOLCHAIN
 
 FROM mcr.microsoft.com/windows/servercore:$WIN_VER
 
@@ -33,3 +35,5 @@ RUN rustup component add clippy
 RUN choco install git -y
 
 RUN rmdir /s /q c:\TEMP
+
+RUN echo "{\"rev\":\"$GIT_COMMIT\",\"branch\":\"${GIT_BRANCH}\",\"cargo-params\":\"${CARGO_PARAMS}\" }" > /buildinfo.json

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -e
+RUST_TOOLCHAIN=1.46
+ARCH=$(uname -m)
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DOCKER_TAG=rustvmm/dev
+DOCKERHUB_LINK=https://hub.docker.com/r/${DOCKER_TAG}/tags
+
+# Get docker tags
+dtags () {
+    local image="${1}";
+    wget -c -q https://registry.hub.docker.com/v1/repositories/"${image}"/tags -O - \
+    | tr -d '[]" ' \
+    | tr '}' '\n' \
+    | awk -F: '{print $3}'
+}
+
+# Get the latest published version. Returns a number.
+# If latest is v100, returns 100.
+latest(){
+  dtags $DOCKER_TAG | grep -v "_" | cut -c 2- | sort -n | tail -1
+}
+
+# Builds the tag for the newest versions. It needs the last published version number.
+# Returns a valid docker tag.
+build_tag(){
+  latest_version=$(latest)
+  new_version=$((latest_version + 1))
+  new_tag=${DOCKER_TAG}:${new_version}_$ARCH
+  echo "$new_tag"
+}
+
+# Build a new docker version.
+# It will build a new docker image with tag latest version + 1
+# and will alias it with "latest" tag.
+build(){
+  new_tag=$(build_tag)
+  docker build -t "$new_tag" \
+        --build-arg RUST_TOOLCHAIN=${RUST_TOOLCHAIN} \
+        --build-arg GIT_BRANCH="${GIT_BRANCH}" \
+        --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+        -f Dockerfile .
+  echo "Build completed for $new_tag"
+}
+
+# Creates and pushes a manifest for a new version
+manifest(){
+  latest_version=$(latest)
+  new_version=$((latest_version + 1))
+  new_tag=${DOCKER_TAG}:${new_version}
+  docker manifest create \
+        $new_tag \
+        "${new_tag}_x86_64" \
+        "${new_tag}_aarch64"
+  echo "Manifest successfully created"
+  docker manifest push $new_tag
+  echo "Manifest successfully pushed on DockerHub: ${DOCKERHUB_LINK}"
+}
+
+publish(){
+    new_tag=$(build_tag)
+    echo "Publishing $new_tag on dockerhub"
+  	docker push "$new_tag"
+  	echo "Successfully published $new_tag on DockerHub: ${DOCKERHUB_LINK}"
+}
+
+case $1 in
+  "build")
+    build;
+    ;;
+  "publish")
+    publish;
+    ;;
+  "manifest")
+    manifest;
+    ;;
+  *)
+   echo "Command $1 not supported. Try with 'publish', 'build' or 'manifest'. ";
+   ;;
+esac


### PR DESCRIPTION
Resolves #44
```
This commit add a script for easing the build
and publish of new docker containers.

To allow auditability, a json with commit and branch
was added to in the container.

The script will also add a tag from latest built version
to latest alias.
```

Example of run:
```
./docker.sh build
Bulding version new_version
docker build -t rustvmm/dev:12_x86_64 --build-arg RUST_TOOLCHAIN=1.49 --build-arg GIT_BRANCH=issue-44 --build-arg GIT_COMMIT=208f69e8b8d45f21ba09c2777f4e936c8dbc236c -f Dockerfile .
Build completed for rustvmm/dev:12_x86_64
```

```
./docker.sh publish
Publishing 12 and 'latest' on dockerhub
+ echo docker push rustvmm/dev:12_x86_64
docker push rustvmm/dev:12_x86_64
+ echo docker push rustvmm/dev:latest
docker push rustvmm/dev:latest
+ set +e +x
```
To allow auditability, I've added a json file with commit and branch. This will allow people to know when the container was built.

---

Tested on a temp tag:
 * ./docker.sh build
 ```
 Successfully tagged federicoponzi/test:1_x86_64
Build completed for federicoponzi/test:1_x86_64
```
* ./docker.sh publish
```
Publishing federicoponzi/test:1_x86_64 on dockerhub
Successfully published federicoponzi/test:1_x86_64 on DockerHub: https://hub.docker.com/r/federicoponzi/test/tags
```
