### PR TITLE
Update to Rust 1.58.1 and simplify Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example of running cargo build on the kvm-ioctls crate:
 > git clone git@github.com:rust-vmm/kvm-ioctls.git
 > cd kvm-ioctls/
 > docker run --volume $(pwd):/kvm-ioctls \
-         rustvmm/dev:v3 \
+         rustvmm/dev:v15 \
          /bin/bash -c "cd /kvm-ioctls && cargo build --release"
  Downloading crates ...
   Downloaded libc v0.2.48
@@ -54,7 +54,7 @@ Example of running cargo build on the kvm-ioctls crate:
 
 ## Available Tools
 
-The container currently has the Rust toolchain version 1.54 and Python3.6.
+The container currently has the Rust toolchain version 1.58.1 and Python3.8.
 
 Python packages:
 

--- a/docker.sh
+++ b/docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-RUST_TOOLCHAIN=1.54
+RUST_TOOLCHAIN=1.58.1
 ARCH=$(uname -m)
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
- Dockerfile has been simplified by grouping all apt dependencies
in one RUN statement.

- Using --no-install-recommends requires even more explicit list
of dependencies which is good for maintanence.

- No need for Rust nightly because fmt in doc comments is suported
on stable.

- No need to install rustfmt and clippy separately.

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>