### PR TITLE
Added iproute2 as a package for virtio-net testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
     cpio bc flex bison wget xz-utils fakeroot \
     # debootstrap to build rootfs images
     debootstrap \
+    # iproute2 for creating tap device
+    iproute2 \
     # cleanup
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Ramyak mehra <rmehra_be19@thapar.edu>

### Summary of the PR

We needed iproute2 to configure tap devices on the host side for testing  virtio-net.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
