### PR TITLE
Fix commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ can check out the Bash expression below.
 ```bash
 DOCKERHUB="https://registry.hub.docker.com/v1/repositories/rustvmm/dev/tags"
 
-VERSION=$(wget -c -q $DOCKERHUB -O -  \
+VERSION=v$(wget -c -q $DOCKERHUB -O -  \
   | tr -d '[]" '                      \
   | tr '}' '\n'                       \
   | awk -F: '{print $3}'              \
@@ -26,7 +26,7 @@ docker pull rustvmm/dev:$VERSION
 ```
 
 Depending on which platform you're running the command from, docker will pull
-either `rustvmm/dev:vX_aarch64` or `rustvmm/dev:vX_x86_64`.
+either `rustvmm/dev:$VERSION_aarch64` or `rustvmm/dev:$VERSION_x86_64`.
 
 For now rust is installed only for the root user.
 
@@ -41,7 +41,7 @@ Example of running cargo build on the kvm-ioctls crate:
 > git clone git@github.com:rust-vmm/kvm-ioctls.git
 > cd kvm-ioctls/
 > docker run --volume $(pwd):/kvm-ioctls \
-         rustvmm/dev:v15 \
+         rustvmm/dev:$VERSION \
          /bin/bash -c "cd /kvm-ioctls && cargo build --release"
  Downloading crates ...
   Downloaded libc v0.2.48


### PR DESCRIPTION
The docker-pull command fails for missing 'v' in $VERSION.
Also, the launched container was not using the latest image as
the hard-coded version value is used in using the container
section. Update documentation in README.md with the fixed commands.

Signed-off-by: nikson <nikson@users.noreply.github.com>

### Summary of the PR

Please see the commit message

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
