### PR TITLE
Allow libgpiod to be installed and bindgen to be run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,10 @@ RUN cargo install cargo-kcov critcmp cargo-audit cargo-license
 # Install kcov.
 RUN cargo kcov --print-install-kcov-sh | sh
 
+# Install libgpiod (required by vhost-device crate)
+RUN cd /opt/ && \
+    git clone --depth 1 --branch v2.0-rc1 https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/ && \
+    cd libgpiod && ./autogen.sh --prefix=/usr && make && make install; \
+    cd
+
 RUN echo "{\"rev\":\"$GIT_COMMIT\",\"branch\":\"${GIT_BRANCH}\"}" > /buildinfo.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update && \
     libdw-dev binutils-dev libiberty-dev make \
     # utilities to build kernels
     cpio bc flex bison wget xz-utils fakeroot \
+    # utilities to build usersapce packages
+    autoconf autoconf-archive automake libtool \
+    # bindgen dependency
+    libclang-dev \
     # debootstrap to build rootfs images
     debootstrap \
     # iproute2 for creating tap device


### PR DESCRIPTION
These package are required to be pre-installed for the vhost-device [1]
workspace's gpio crate. This pull reuqest adds support to install them.

This is required to migrate vhost-device to the mainline version of libgpiod [2].

[1] https://github.com/rust-vmm/vhost-device
[2] https://github.com/rust-vmm/vhost-device/pull/279

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>