### PR TITLE
fix build-and-push step in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,9 +8,6 @@ on:
     branches: [ "main" ]
     paths: [Dockerfile, .github/workflows/docker-publish.yml]
 
-env:
-  IMAGE_NAME: rustvmm/dev
-
 jobs:
   build:
 
@@ -47,18 +44,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_ACCOUNT_ID }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
       - name: Generate next docker tag
+        # NOTE: The tag contains the full docker container name + tag as it is requested
+        # by the build-and-push step.
         run: |
           echo "VERSION=$(./docker.sh print-next-version)" >> $GITHUB_ENV
           echo "Next version to be published is: ${{ env.VERSION }}"
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: rustvmm/dev
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/docker.sh
+++ b/docker.sh
@@ -20,6 +20,10 @@ next_version() {
     echo "$new_version"
 }
 
+print_next_version() {
+  echo "rustvmm/dev:v$(next_version)"
+}
+
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
@@ -72,7 +76,7 @@ case $1 in
     manifest;
     ;;
   "print-next-version")
-    next_version;
+    print_next_version;
     ;;
   *)
    echo "Command $1 not supported. Try with 'publish', 'build', 'manifest' or 'print-next-version'. ";


### PR DESCRIPTION
### Summary of the PR

The step actually needs the full name of the docker registry
+ the tag. Since we are computing this ourselves, we shouldn't need the metadata, so that step is now deleted.

Updated the docker.sh script to just give us the full name.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
