### PR TITLE
build_container: Add tools required by bindgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-ARG RUST_TOOLCHAIN="1.67.1"
+ARG RUST_TOOLCHAIN="1.68.2"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"

--- a/build_container.sh
+++ b/build_container.sh
@@ -10,7 +10,7 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libdw-dev binutils-dev libiberty-dev make \
     cpio bc flex bison wget xz-utils fakeroot \
     autoconf autoconf-archive automake libtool \
-    iproute2
+    libclang-dev iproute2
 
 # cleanup
 apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Some packages need to build FFI bindings dynamically using 'bindgen' and 'bindgen' requires libclang-dev to be available.

This was removed accidentally by commit d1a36b4b2af5 ("reduce the size occupied during build by container").

Get it back.