### PR TITLE
build_container: use git cli to avoid OOM on arm64

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -21,7 +21,11 @@ pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y 
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
 
 # Install cargo tools.
-cargo install cargo-kcov critcmp cargo-audit cargo-fuzz && rm -rf /root/.cargo/registry/
+# Use `git` executable to avoid OOM on arm64:
+# https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
+cargo --config "net.git-fetch-with-cli = true" \
+    install cargo-kcov critcmp cargo-audit cargo-fuzz
+rm -rf /root/.cargo/registry/
 
 # Install nightly (needed for fuzzing)
 rustup install --profile=minimal nightly


### PR DESCRIPTION
libgit2 can consume a lot of memory when cross-compiling for arm64. As suggested here [1], let's use the git executable to prevent this issue.

[1] https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984

Fixes: https://github.com/rust-vmm/rust-vmm-container/issues/79

