### PR TITLE
Replace cargo-kcov with llvm-cov

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -24,18 +24,18 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAI
 # Use `git` executable to avoid OOM on arm64:
 # https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
 cargo --config "net.git-fetch-with-cli = true" \
-    install cargo-kcov critcmp cargo-audit cargo-fuzz
+    install critcmp cargo-audit cargo-fuzz
 rm -rf /root/.cargo/registry/
 
 # Install nightly (needed for fuzzing)
 rustup install --profile=minimal nightly
 rustup component add miri rust-src --toolchain nightly
+rustup component add llvm-tools-preview  # needed for coverage
 
 # Install other rust targets.
 rustup target add $(uname -m)-unknown-linux-musl
 
-# Install kcov.
-cargo kcov --print-install-kcov-sh | sh
+cargo install cargo-llvm-cov
 
 # Install libgpiod (required by vhost-device crate)
 pushd /opt


### PR DESCRIPTION
cargo-kcov is no longer working as of rust toolchain version 1.71.0, as it can no longer discover test executables. This is due to cargo changing its verbose stdout printing to include the qualified path to rustc, which causes cargo-kcov's string matching to fail.

See also https://github.com/kennytm/cargo-kcov/issues/54

cargo-kcov has had its last commit in 2019, so replace it with cargo-llvm-cov, which is actively maintained, and written for rust.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
