### PR TITLE
build_container: update libgpiod

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -39,8 +39,14 @@ cargo install cargo-llvm-cov
 
 # Install libgpiod (required by vhost-device crate)
 pushd /opt
-git clone --depth 1 --branch v2.0 https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
+mkdir libgpiod
 pushd libgpiod
+git init
+git remote add origin https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
+# bindings: rust: libgpiod: release 0.2.0
+LIBGPIOD_COMMIT="e7b02c2259d97c77107c77b68e3bc1664e6703c1"
+git fetch --depth=1 origin "$COMMIT"
+git reset --hard FETCH_HEAD
 ./autogen.sh --prefix=/usr && make && make install
 popd
 rm -rf libgpiod


### PR DESCRIPTION
There are some unresolved discussions [1] on how to support older versions of libgpiod. But right now, the latest Rust bindings require a snapshot from the master branch.

We need the latest version since it fixes some threading contracts.

So for now, we just update to a compatible git commit.

[1] https://lore.kernel.org/r/20231006-b4-bindings-old-version-fix-v1-0-a65f431afb97@linaro.org

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
