### PR TITLE
Don't install rustdoc along with default Rust toolchain

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -18,7 +18,9 @@ apt-get clean && rm -rf /var/lib/apt/lists/*
 pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
 
 # Install rustup and a fixed version of Rust.
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
+curl https://sh.rustup.rs -sSf | sh -s -- \
+  -y --default-toolchain "$RUST_TOOLCHAIN" \
+  --profile minimal --component clippy,rustfmt
 
 # Install cargo tools.
 # Use `git` executable to avoid OOM on arm64:


### PR DESCRIPTION

### Summary of the PR

Downloading and installing rustdoc every time the image is built takes considerable time that is not necessary, so specify only the rustup components we need.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
