### PR TITLE
Initial riscv64 support for rust-vmm-container

### DIFF
--- a/.github/workflows/docker-publish-riscv64.yml
+++ b/.github/workflows/docker-publish-riscv64.yml
@@ -1,0 +1,85 @@
+name: Docker
+
+on:
+  push:
+    branches: [ "main" ]
+    paths: [Dockerfile.riscv64, .github/workflows/docker-publish-riscv64.yml, build_container_riscv64*, riscv64/**]
+  pull_request:
+    branches: [ "main" ]
+    paths: [Dockerfile.riscv64, .github/workflows/docker-publish-riscv64.yml, build_container_riscv64*, riscv64/**]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.1.1
+      - name: Check install!
+        if: github.event_name != 'pull_request'
+        run: cosign version
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          username: ${{ secrets.DOCKER_ACCOUNT_ID }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Generate next docker tag
+        # NOTE: The tag contains the full docker container name + tag as it is requested
+        # by the build-and-push step.
+        env:
+          ARCH: riscv64
+        run: |
+          echo "VERSION=$(./docker.sh print-next-version)" >> $GITHUB_ENV
+      - name: Print next docker tag
+        run: |
+          echo "Next version to be published is: ${{ env.VERSION }}"
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          file: Dockerfile.riscv64
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64
+          tags: ${{ env.VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,54 @@
+#==============================
+# Builder Stage
+# Compile QEMU, cross-compile OpenSBI, Linux
+#==============================
+FROM ubuntu:22.04 AS builder
+
+COPY build_container_riscv64.builder.sh /opt/src/scripts/build_container_riscv64.builder.sh
+RUN /opt/src/scripts/build_container_riscv64.builder.sh
+
+#==============================
+# Rootfs Stage
+# Generate guest rootfs
+#==============================
+FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 AS rootfs_builder
+
+COPY build_container_riscv64.rootfs.sh /opt/src/scripts/build_container_riscv64.rootfs.sh
+RUN /opt/src/scripts/build_container_riscv64.rootfs.sh
+
+## Install test service that run CI test on systemd boot
+COPY riscv64/test.service /etc/systemd/system/
+COPY riscv64/test-service.sh /bin/
+RUN systemctl enable test
+
+## Install network-related configurations
+COPY riscv64/interfaces /etc/network/
+COPY riscv64/resolv.conf /etc/
+
+#==============================
+# Final-Stage Docker Image
+#==============================
+FROM ubuntu:22.04 AS final
+
+COPY build_container_riscv64.final.sh /opt/src/scripts/build_container_riscv64.final.sh
+RUN /opt/src/scripts/build_container_riscv64.final.sh
+
+#--------------------
+# Directories to be installed from builder and rootfs_builder
+#--------------------
+ARG OUTPUT_DIR=/opt/bin
+ARG INSTALL_DIR=/opt/install
+ARG ROOTFS_DIR=/rootfs
+
+#--------------------
+# Combining all stages
+#--------------------
+COPY --from=builder $OUTPUT_DIR $OUTPUT_DIR
+COPY --from=builder $INSTALL_DIR $INSTALL_DIR
+COPY --from=rootfs_builder / $ROOTFS_DIR
+
+## Install script for starting QEMU RISC-V guest
+COPY riscv64/qemu.sh /bin/
+
+## rust path and qemu path
+ENV PATH="$PATH:/root/.cargo/bin:$INSTALL_DIR/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
 
 **`rustvmm/dev`** is a container with all dependencies used for running
 `rust-vmm` integration and performance tests. The container is available on
-Docker Hub and has support for `x86_64` and `aarch64` platforms.
+Docker Hub and has support for `x86_64` and `aarch64` platforms.  
+`riscv64` CI is also supported but using [workaround explained here](#workaround-for-supporting-risc-v-ci).  
 
-For the latest available tag, please check the `rustvmm/dev` builds available
-on [Docker Hub](https://hub.docker.com/r/rustvmm/dev/tags).
+Due to the workaround, we have two separate Docker Hub repositories:
+- For the latest available tag for `x86_64` and `aarch64`, 
+please check the `rustvmm/dev` builds available on 
+[Docker Hub](https://hub.docker.com/r/rustvmm/dev/tags).  
+- For the latest available tag for `riscv64`, 
+please check the `rustvmm/dev_riscv64` builds available on 
+[Docker Hub](https://hub.docker.com/r/rustvmm/dev_riscv64/tags).
 
 ## Know Issues
 
 For now rust is installed only for the root user.
+
+### Workaround for supporting RISC-V CI
+Unlike x86/ARM CI, currently there is no RISC-V Buildkite agent platform.  
+As a workaround, QEMU is used to run RISC-V CI on x86 Buildkite agent platform.  
+As a result,
+- a dedicated `Dockerfile.riscv64` is used to build such container image containing QEMU along with cross-compiled OpenSBI, Linux, and rootfs.
+- a dedicated [Docker Hub repository](https://hub.docker.com/r/rustvmm/dev_riscv64/tags) `rustvmm/dev_riscv64` is used to store such container image.
 
 ## Using the Container
 
@@ -32,6 +45,8 @@ Example of running cargo build on the kvm-ioctls crate:
    Compiling kvm-ioctls v0.0.1 (/kvm-ioctls)
     Finished release [optimized] target(s) in 5.63s
 ```
+
+Examples of running cargo build/test for riscv64 can be found in [riscv64/examples/docker-test.sh](`riscv64/examples/docker-test.sh`).
 
 ## Publishing a New Version
 
@@ -58,6 +73,7 @@ that are allowed to publish containers:
 - [Laura Loghin](https://github.com/lauralt)
 - and the rust-vmm bot account
 
+#### Manual Publish for `x86_64` and `aarch64`
 On an `aarch64` platform:
 
 ```bash
@@ -83,3 +99,14 @@ fail with: ```docker manifest is only supported when experimental cli features
 are enabled```. Checkout
 [this article](https://medium.com/@mauridb/docker-multi-architecture-images-365a44c26be6)
 to understand why and how to fix it.
+
+#### Manual Publish for `riscv64`
+For `riscv64` CI container image, the above steps are a little bit different due to the [workaround](#workaround-for-supporting-risc-v-ci) needed to support `riscv64` CI:
+- `ARCH=riscv64` needs to be specified because `riscv64` has dedicated Dockerfile.riscv64 and Docker Hub repository.
+- The commands are run on x86 platform because the container image is to be run on x86 Buildkite agent platform.
+```bash
+> cd rust-vmm-container
+> ARCH=riscv64 ./docker.sh build
+> ARCH=riscv64 ./docker.sh publish
+> ARCH=riscv64 ./docker.sh manifest
+```

--- a/build_container_riscv64.builder.sh
+++ b/build_container_riscv64.builder.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -ex
+
+export ARCH=riscv
+export CROSS_COMPILE=riscv64-linux-gnu-
+
+#--------------------
+# Version tags
+#--------------------
+QEMU_TAG=v8.1.2
+OPENSBI_TAG=v1.3.1
+LINUX_TAG=v6.5
+
+#--------------------
+# Directory paths
+#--------------------
+## Directory path where git clones repos to
+DIR_PREFIX=/opt/build
+mkdir -p $DIR_PREFIX
+## Build output path (to store output of make)
+OUTPUT_DIR=/opt/bin
+mkdir -p $OUTPUT_DIR
+## Build install path (to store output of make install)
+INSTALL_DIR=/opt/install
+
+## Repo paths
+QEMU_DIR=$DIR_PREFIX/qemu
+OPENSBI_DIR=$DIR_PREFIX/opensbi
+LINUX_DIR=$DIR_PREFIX/linux
+
+#--------------------
+# Prerequisites
+#--------------------
+PACKAGE_LIST="git python3 python3-pip build-essential pkg-config libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build gcc-riscv64-linux-gnu libssl-dev wget curl bc flex bison libslirp-dev"
+apt-get update
+apt-get -y install $PACKAGE_LIST
+
+cd $DIR_PREFIX
+git clone --depth 1 --branch $QEMU_TAG https://gitlab.com/qemu-project/qemu.git
+git clone --depth 1 --branch $OPENSBI_TAG https://github.com/riscv-software-src/opensbi.git
+git clone --depth 1 --branch $LINUX_TAG https://github.com/torvalds/linux.git
+
+#--------------------
+# QEMU
+#--------------------
+cd $QEMU_DIR
+./configure --target-list="riscv64-softmmu" --enable-slirp --prefix=$INSTALL_DIR/usr/local && \
+	make -j$(nproc) && \
+	make install
+
+#--------------------
+# OpenSBI
+#--------------------
+cd $OPENSBI_DIR
+make -j$(nproc) PLATFORM=generic
+mv $OPENSBI_DIR/build/platform/generic/firmware/fw_jump.elf $OUTPUT_DIR
+
+#--------------------
+# Linux
+#--------------------
+cd $LINUX_DIR
+sed -i "s|^CONFIG_KVM=.*|CONFIG_KVM=y|g" $LINUX_DIR/arch/riscv/configs/defconfig
+make defconfig && make -j$(nproc)
+mv $LINUX_DIR/arch/riscv/boot/Image $OUTPUT_DIR
+
+#--------------------
+# Cleanup
+#--------------------
+rm -rf $QEMU_DIR
+rm -rf $OPENSBI_DIR
+rm -rf $LINUX_DIR
+apt-get -y remove $PACKAGE_LIST

--- a/build_container_riscv64.final.sh
+++ b/build_container_riscv64.final.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+#--------------------
+# Version tag
+#--------------------
+RUST_TOOLCHAIN="1.75.0"
+export PATH="$PATH:/root/.cargo/bin"
+
+#--------------------
+# Prerequisites
+#--------------------
+apt-get update
+apt-get -y install curl libglib2.0-dev libfdt-dev libpixman-1-dev libslirp-dev gcc gcc-riscv64-linux-gnu
+
+curl https://sh.rustup.rs -sSf | sh -s -- \
+	    -y --default-toolchain "$RUST_TOOLCHAIN" \
+	    --profile minimal --component clippy,rustfmt
+rustup target add riscv64gc-unknown-linux-gnu

--- a/build_container_riscv64.rootfs.sh
+++ b/build_container_riscv64.rootfs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+apt-get update
+apt-get -y upgrade
+apt-get -y install systemd init ifupdown busybox udev

--- a/docker.sh
+++ b/docker.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -e
-ARCH=$(uname -m)
+ARCH=${ARCH:-$(uname -m)}
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-DOCKER_TAG=rustvmm/dev
+# Due to the workaround to support RISC-V CI (as explained in README.md),
+# for riscv64, ARCH=riscv64 needs to be specified because of dedicated Dockerfile.riscv64 and Docker Hub repository.
+case $ARCH in
+  riscv | riscv64)
+    DOCKER_TAG=rustvmm/dev_riscv64
+    ;;
+  *)
+    DOCKER_TAG=rustvmm/dev
+    ;;
+esac
 
 # Get the latest published version. Returns a number.
 # If latest is v100, returns 100.
 # This works as long as we have less than 100 tags because we set the page size to 100,
 # once we have more than that this script needs to be updated.
 latest(){
-  curl -L -s 'https://registry.hub.docker.com/v2/repositories/rustvmm/dev/tags?page_size=100'| \
+  curl -L -s "https://registry.hub.docker.com/v2/repositories/${DOCKER_TAG}/tags?page_size=100"| \
     jq '."results"[]["name"]' |  sed 's/"//g' | cut -c 2- | grep -E "^[0-9]+$" | sort -n | tail -1
 }
 
@@ -21,14 +30,21 @@ next_version() {
 }
 
 print_next_version() {
-  echo "rustvmm/dev:v$(next_version)"
+  echo "${DOCKER_TAG}:v$(next_version)"
 }
 
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
   new_version=$(next_version)
-  new_tag=${DOCKER_TAG}:v${new_version}_$ARCH
+  case $ARCH in
+    riscv | riscv64)
+      new_tag=${DOCKER_TAG}:v${new_version}_riscv64
+      ;;
+    *)
+      new_tag=${DOCKER_TAG}:v${new_version}_$ARCH
+      ;;
+  esac
   echo "$new_tag"
 }
 
@@ -37,10 +53,19 @@ build_tag(){
 # and will alias it with "latest" tag.
 build(){
   new_tag=$(build_tag)
+  case $ARCH in
+    riscv | riscv64)
+      dockerfile=Dockerfile.riscv64
+      ;;
+    *)
+      dockerfile=Dockerfile
+      ;;
+  esac
+  echo "docker build"
   docker build -t "$new_tag" \
         --build-arg GIT_BRANCH="${GIT_BRANCH}" \
         --build-arg GIT_COMMIT="${GIT_COMMIT}" \
-        -f Dockerfile .
+        -f $dockerfile .
   echo "Build completed for $new_tag"
 }
 
@@ -49,10 +74,19 @@ manifest(){
   latest_version=$(latest)
   new_version=$((latest_version + 1))
   new_tag=${DOCKER_TAG}:v${new_version}
-  docker manifest create \
-        $new_tag \
-        "${new_tag}_x86_64" \
-        "${new_tag}_aarch64"
+  case $ARCH in
+    riscv | riscv64)
+      docker manifest create \
+            $new_tag \
+            "${new_tag}_riscv64"
+      ;;
+    *)
+      docker manifest create \
+            $new_tag \
+            "${new_tag}_x86_64" \
+            "${new_tag}_aarch64"
+      ;;
+  esac
   echo "Manifest successfully created"
   docker manifest push $new_tag
   echo "Manifest successfully pushed on DockerHub: ${DOCKERHUB_LINK}"

--- a/riscv64/examples/docker-build.sh
+++ b/riscv64/examples/docker-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+current_dir="$(dirname $(readlink -f "$0"))"
+cd $current_dir/../..
+
+ARCH=riscv64 ./docker.sh build

--- a/riscv64/examples/docker-run.sh
+++ b/riscv64/examples/docker-run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+REPO_DIR=/tmp/linux-loader
+REPO_MOUNT_POINT=/workdir
+IMAGE_TAG=$(ARCH=riscv64 ../../docker.sh print-next-version)_riscv64
+
+docker run -it -v $REPO_DIR:$REPO_MOUNT_POINT --workdir $REPO_MOUNT_POINT $IMAGE_TAG bash

--- a/riscv64/examples/docker-test.sh
+++ b/riscv64/examples/docker-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+REPO_DIR=/tmp/linux-loader
+REPO_MOUNT_POINT=/workdir
+IMAGE_TAG=$(ARCH=riscv64 ../../docker.sh print-next-version)_riscv64
+
+## CI: build-gnu-riscv64
+echo "build-gnu-riscv64"
+docker run -it --rm \
+	-v $REPO_DIR:$REPO_MOUNT_POINT \
+	--workdir $REPO_MOUNT_POINT \
+	$IMAGE_TAG \
+	sh -c -e \
+	"trap 'chown -R $(id -u):$(id -u) $REPO_MOUNT_POINT' 0; \
+	RUSTFLAGS=\"-D warnings\" \
+	cargo build --release --target=riscv64gc-unknown-linux-gnu \
+	--config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\""
+
+## CI: unittests-gnu-riscv64
+echo "unittests-gnu-riscv64"
+docker run -it --rm \
+	-v $REPO_DIR:$REPO_MOUNT_POINT \
+	--workdir $REPO_MOUNT_POINT \
+	$IMAGE_TAG \
+	sh -c -e \
+	"trap 'chown -R $(id -u):$(id -u) $REPO_MOUNT_POINT' 0; \
+	cargo test --no-run \
+	--target=riscv64gc-unknown-linux-gnu \
+	--config target.riscv64gc-unknown-linux-gnu.linker=\\\"riscv64-linux-gnu-gcc\\\" \
+	&& qemu.sh"

--- a/riscv64/interfaces
+++ b/riscv64/interfaces
@@ -1,0 +1,5 @@
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp

--- a/riscv64/qemu.sh
+++ b/riscv64/qemu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+## This script is executed by the host inside Docker to run QEMU RISC-V guest
+OUTPUT_DIR=/opt/bin
+OPENSBI_FW_JUMP_ELF=$OUTPUT_DIR/fw_jump.elf
+LINUX_IMAGE=$OUTPUT_DIR/Image
+ROOTFS_DIR=/rootfs
+## The repo to be tested (the repo passed in by Docker host, will be passed to QEMU guest at the same path)
+REPO_MOUNT_POINT=/workdir
+
+echo "Running QEMU..."
+qemu-system-riscv64 \
+	-M virt -nographic \
+	-smp 6 -cpu rv64,h=true \
+	-m 6G \
+	-bios $OPENSBI_FW_JUMP_ELF \
+	-kernel $LINUX_IMAGE \
+	-device virtio-net-device,netdev=usernet -netdev user,id=usernet\
+	-virtfs local,path=$ROOTFS_DIR,mount_tag=rootfs,security_model=none,id=rootfs \
+	-append "root=rootfs rw rootfstype=9p rootflags=trans=virtio,cache=mmap,msize=512000 console=ttyS0 earlycon=sbi nokaslr rdinit=/sbin/init" \
+	-virtfs local,path=$REPO_MOUNT_POINT,mount_tag=test,security_model=mapped,id=test

--- a/riscv64/resolv.conf
+++ b/riscv64/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 8.8.8.8

--- a/riscv64/test-service.sh
+++ b/riscv64/test-service.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+## This script is executed by QEMU RISC-V guest during systemd boot (see test.service)
+## This script does the following things:
+## 1) mount the repo to be tested at $REPO_MOUNT_POINT
+## 2) find pre-cross-compiled test binaries under $REPO_MOUNT_POINT/target/riscv64gc-unknown-linux-gnu/debug/deps/*
+## 3) Run each of those found test binaries
+
+## QEMU virtfs mount_tag
+REPO_MOUNT_TAG=test
+## Where to mount the repo to be tested, the repo shall be pre-cross-compiled in host machine
+REPO_MOUNT_POINT=/workdir
+
+## $1: The exit code (in decimal) that you want QEMU to exit with
+exit_qemu_with_code() {
+	local exit_code=$1
+	local exit_code_in_hex=$(printf "0x%x" $exit_code)
+	local encoded_exit_code=$(printf "0x%x" $(( ($exit_code_in_hex << 16) + 0x3333)))
+	echo "Exiting QEMU with exit code $exit_code..."
+	## Trigger QEMU exit by writing to SiFive Test MMIO device at 0x100000
+	busybox devmem 0x100000 w $encoded_exit_code
+}
+
+trap 'exit_qemu_with_code $?' 0
+
+echo "Mounting repo to be tested..."
+mkdir -p $REPO_MOUNT_POINT
+mount -t 9p -o rw,trans=virtio,version=9p2000.L,posixacl,cache=mmap,msize=512000 $REPO_MOUNT_TAG $REPO_MOUNT_POINT
+mount | grep 9p
+
+echo "Searching for cross-compiled test binaries..."
+IFS=$'\n'
+test_bin=($(find $REPO_MOUNT_POINT/target/riscv64gc-unknown-linux-gnu/debug/deps/* -perm /+x))
+unset IFS
+
+echo "List of cross-compiled test binaries found..."
+printf "%s\n" "${test_bin[@]}"
+
+echo "Running the cross-compiled test binaries..."
+for (( i = 0; i < ${#test_bin[@]} ; i++ )); do
+	echo "*****************************************"
+	echo "Running: $(basename ${test_bin[$i]})"
+	echo "*****************************************"
+	eval "${test_bin[$i]}"
+done

--- a/riscv64/test.service
+++ b/riscv64/test.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Test Service
+After=multi-user.target
+
+[Service]
+Type=idle
+ExecStart=/bin/test-service.sh
+StandardOutput=tty
+TTYPath=/dev/ttyS0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request is to introduce riscv64 Docker image for rust-vmm CI purpose.

Unlike x86/ARM CI test, we don't have native server for RISC-V.
As a workaround, QEMU can be used so that we can run RISC-V CI on x86/ARM CI server.

The CI flow using QEMU looks like this:
1. Pass the repo to be tested as a volume to Docker container.
2. In the container, cross-compile the repo (I did try Rust RISC-V native toolchain, but it seems unstable at the moment).
3. The Docker container proceed to launch a QEMU RISC-V guest and pass the cross-compiled repo to the guest using 9pfs.
4. The guest boots, and during init, a custom systemd service (test.service) will mount the 9pfs, which then searches and runs all the cross-compiled test binaries in that 9pfs mount point.
5. The guest writes to virt test MMIO device using devmem utility to trigger QEMU exit with custom exit code.
6. The exit code is passed along the exit path from QEMU to Docker container and back to host CI server.

To better explain the CI flow, I also made a YouTube video:
https://youtu.be/r2OhfmPq74U

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.