### PR TITLE
github: use current default cosign

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,10 +27,10 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.13.1'
-
+        uses: sigstore/cosign-installer@v3.1.1
+      - name: Check install!
+        if: github.event_name != 'pull_request'
+        run: cosign version
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx


### PR DESCRIPTION
We have a few hoops to jump to get the github action working. I have tested the cosign install works with a temp branch but the PR tests will fail until the workflow has had a chance to install cosign after its merged.