### PR TITLE
feat(build_container): add no_std-only targets

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -37,7 +37,7 @@ rustup component add miri rust-src --toolchain nightly
 rustup component add llvm-tools-preview  # needed for coverage
 
 # Install other rust targets.
-rustup target add $(uname -m)-unknown-linux-musl
+rustup target add $(uname -m)-unknown-linux-musl $(uname -m)-unknown-none
 
 cargo install cargo-llvm-cov
 


### PR DESCRIPTION
### Summary of the PR

This is useful for verifying that `no_std` crates actually work on `no_std` targets.

See https://github.com/rust-vmm/vm-fdt/pull/68.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
