### PR TITLE
build_container.sh: use eatmydata for apt operations

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -ex
 
-apt-get update
-
 # DEBIAN_FRONTEND is set for tzdata.
-DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+export DEBIAN_FRONTEND="noninteractive"
+
+apt-get update && \
+  apt-get install -y eatmydata
+
+
+eatmydata apt-get install --no-install-recommends -y \
     curl gcc git python3 python3-pip shellcheck \
     libssl-dev tzdata cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev \
     libdw-dev binutils-dev libiberty-dev make \
@@ -15,9 +19,9 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
 
 # cleanup
-apt-get clean && rm -rf /var/lib/apt/lists/*
+eatmydata apt-get clean && rm -rf /var/lib/apt/lists/*
 
-pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
+pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && eatmydata apt purge -y python3-pip
 
 # Install rustup and a fixed version of Rust.
 curl https://sh.rustup.rs -sSf | sh -s -- \


### PR DESCRIPTION
### Summary of the PR

eatmydata disables fsync and similar operations to speed up data operations for ephemeral tasks (like building a container image).

See: https://packages.debian.org/bookworm/eatmydata




### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
