### PR TITLE
Fixing container build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-ARG RUST_TOOLCHAIN="1.72.0"
+ARG RUST_TOOLCHAIN="1.75.0"
 ARG ARCH
 
 # Adding rust binaries to PATH.

--- a/docker.sh
+++ b/docker.sh
@@ -40,7 +40,7 @@ build(){
   docker build -t "$new_tag" \
         --build-arg GIT_BRANCH="${GIT_BRANCH}" \
         --build-arg GIT_COMMIT="${GIT_COMMIT}" \
-        -f Dockerfile .
+        -f Dockerfile --build-arg ARCH="${ARCH}" .
   echo "Build completed for $new_tag"
 }
 


### PR DESCRIPTION
### Summary of the PR
This PR fixes an issue introduced in #98 with regards to the `ARCH` env variable not being passed to the build script.

Also updates rust toolchain to 1.75

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
