### PR TITLE
fix: replaced ARCH with `uname -m`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:22.04
 ARG RUST_TOOLCHAIN="1.75.0"
-ARG ARCH
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"

--- a/build_container.sh
+++ b/build_container.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+ARCH=$(uname -m)
+
 apt-get update
 
 # DEBIAN_FRONTEND is set for tzdata.
@@ -18,8 +20,8 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # help musl-gcc find linux headers
-pushd /usr/include/$(uname -m)-linux-musl 
-ln -s ../$(uname -m)-linux-gnu/asm asm 
+pushd /usr/include/$ARCH-linux-musl 
+ln -s ../$ARCH-linux-gnu/asm asm 
 ln -s ../linux linux 
 ln -s ../asm-generic asm-generic
 popd
@@ -44,7 +46,7 @@ rustup component add miri rust-src --toolchain nightly
 rustup component add llvm-tools-preview  # needed for coverage
 
 # Install other rust targets.
-rustup target add $(uname -m)-unknown-linux-musl $(uname -m)-unknown-none
+rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 
 cargo install cargo-llvm-cov
 

--- a/build_container.sh
+++ b/build_container.sh
@@ -18,10 +18,11 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # help musl-gcc find linux headers
-cd /usr/include/$(uname -m)-linux-musl \
-    && ln -s ../$(uname -m)-linux-gnu/asm asm \
-    && ln -s ../linux linux \
-    && ln -s ../asm-generic asm-generic
+pushd /usr/include/$(uname -m)-linux-musl 
+ln -s ../$(uname -m)-linux-gnu/asm asm 
+ln -s ../linux linux 
+ln -s ../asm-generic asm-generic
+popd
 
 pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
 

--- a/build_container.sh
+++ b/build_container.sh
@@ -18,8 +18,8 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # help musl-gcc find linux headers
-cd /usr/include/$ARCH-linux-musl \
-    && ln -s ../$ARCH-linux-gnu/asm asm \
+cd /usr/include/$(uname -m)-linux-musl \
+    && ln -s ../$(uname -m)-linux-gnu/asm asm \
     && ln -s ../linux linux \
     && ln -s ../asm-generic asm-generic
 

--- a/docker.sh
+++ b/docker.sh
@@ -40,7 +40,7 @@ build(){
   docker build -t "$new_tag" \
         --build-arg GIT_BRANCH="${GIT_BRANCH}" \
         --build-arg GIT_COMMIT="${GIT_COMMIT}" \
-        -f Dockerfile --build-arg ARCH="${ARCH}" .
+        -f Dockerfile .
   echo "Build completed for $new_tag"
 }
 


### PR DESCRIPTION
### Summary of the PR

In the previous commits/PR (#99, #98) the ARCH
env variable was introduced to the Dockerfile
and build_container.sh scripts. It was meant to
help with configuration of linux headers for
musl-tools, but did not work for some reason.
Considering the build_container.sh was already
using `uname -m` calls to get the current arch
this commit also uses it, so there is no need
for ARCH anymore.

Also removed `&&` from the scripts and moved `$(uname -m)` to one global var.

For reviewers: don't approve before the CI is finished and it is clear that this PR fixes the issue.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
