### PR TITLE
Add support for RISC-V code cross compilation test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG RUST_TOOLCHAIN="1.75.0"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
+# Adding riscv cross compilation toolchain to PATH.
+ENV PATH="$PATH:/opt/riscv/bin"
 
 COPY build_container.sh /opt/src/scripts/build_container.sh
 RUN /opt/src/scripts/build_container.sh


### PR DESCRIPTION
Add steps needed for RISC-V specific code to cross-compile.

### Summary of the PR

I'm proposing using x86_64 platform to cross-compile RISC-V code and `qemu-riscv64-static` to test the compiled binary as a temporary solution, since RISC-V machines are yet available on BuildKite.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
