### PR TITLE
Add libepoxy dependencies for vhost-device-gpu

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -14,6 +14,7 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     autoconf autoconf-archive automake libtool \
     libclang-dev iproute2 \
     libasound2 libasound2-dev \
+    libepoxy0 libepoxy-dev \
     debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
 
 # cleanup


### PR DESCRIPTION

### Summary of the PR

the vhost-device-gpu crate linked here in the PR
https://github.com/rust-vmm/vhost-device/pull/668
contains rutabaga_gfx that requires epoxy library

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
