### PR TITLE
[Draft] Introduce `riscv64` image from Ubuntu LTS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,6 +68,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Build and push riscv64 Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push riscv64 Docker image
+        id: build-and-push-riscv64
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          file: Dockerfile.riscv64
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/riscv64
+          tags: ${{ env.VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
@@ -80,4 +94,6 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: | 
+          echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+          echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push-riscv64.outputs.digest }}

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,11 @@
+# This Dockerfile is a temporory solution for enabling RISC-V CIs, and is
+# expected to be remove when an Ubuntu LTS image is available on `riscv64`
+# platform.
+FROM ubuntu:24.10
+ARG RUST_TOOLCHAIN="1.75.0"
+
+# Adding rust binaries to PATH.
+ENV PATH="$PATH:/root/.cargo/bin"
+
+COPY build_container_riscv.sh /opt/src/scripts/build_container.sh
+RUN /opt/src/scripts/build_container.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **`rustvmm/dev`** is a container with all dependencies used for running
 `rust-vmm` integration and performance tests. The container is available on
-Docker Hub and has support for `x86_64` and `aarch64` platforms.
+Docker Hub and has support for `x86_64`, `aarch64` and `riscv64`  platforms.
 
 For the latest available tag, please check the `rustvmm/dev` builds available
 on [Docker Hub](https://hub.docker.com/r/rustvmm/dev/tags).

--- a/build_container_riscv.sh
+++ b/build_container_riscv.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -ex
+
+# This script is a temporory solution for enabling RISC-V CIs, and is expected
+# to be remove when an Ubuntu LTS image is available on `riscv64` platform.
+
+ARCH=$(uname -m)
+
+apt-get update
+
+# DEBIAN_FRONTEND is set for tzdata.
+DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    curl gcc musl-tools git python3 python3-pip shellcheck \
+    libssl-dev tzdata cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev \
+    libdw-dev binutils-dev libiberty-dev make \
+    cpio bc flex bison wget xz-utils fakeroot \
+    autoconf autoconf-archive automake libtool \
+    libclang-dev iproute2 \
+    libasound2t64 libasound2-dev \
+    libepoxy0 libepoxy-dev \
+    debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
+
+# cleanup
+apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Turn off externally managed check
+mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.bak
+pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
+
+# Install rustup and a fixed version of Rust.
+curl https://sh.rustup.rs -sSf | sh -s -- \
+  -y --default-toolchain "$RUST_TOOLCHAIN" \
+  --profile minimal --component clippy,rustfmt
+
+# Install cargo tools.
+# Use `git` executable to avoid OOM on arm64:
+# https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
+cargo --config "net.git-fetch-with-cli = true" \
+    install critcmp cargo-audit cargo-fuzz
+rm -rf /root/.cargo/registry/
+
+# Install nightly (needed for fuzzing)
+rustup install --profile=minimal nightly
+rustup component add miri rust-src --toolchain nightly
+rustup component add llvm-tools-preview  # needed for coverage
+
+cargo install cargo-llvm-cov
+
+# dbus-daemon expects this folder
+mkdir /run/dbus

--- a/docker.sh
+++ b/docker.sh
@@ -52,7 +52,8 @@ manifest(){
   docker manifest create \
         $new_tag \
         "${new_tag}_x86_64" \
-        "${new_tag}_aarch64"
+        "${new_tag}_aarch64" \
+        "${new_tag}_riscv64"
   echo "Manifest successfully created"
   docker manifest push $new_tag
   echo "Manifest successfully pushed on DockerHub: ${DOCKERHUB_LINK}"


### PR DESCRIPTION
### Summary of the PR

This PR is to be considered when AWS has `riscv64` machines available.

For introducing viable CIs and bringing `riscv64` architecture related code into `rust-vmm` community on `riscv64` platforms, an according docker image is required. This PR covers both upgrading of ubuntu base image from 22.04 to 24.10 (which has native support on `riscv64`) and modifications are architectural related.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
