### PR TITLE
github: fix "Generate next docker tag" log output

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,8 +49,9 @@ jobs:
         # NOTE: The tag contains the full docker container name + tag as it is requested
         # by the build-and-push step.
         run: |
-          echo "VERSION=$(./docker.sh print-next-version)" >> $GITHUB_ENV
-          echo "Next version to be published is: ${{ env.VERSION }}"
+          NEXT_VERSION=$(./docker.sh print-next-version)
+          echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
+          echo "Next version to be published is: ${NEXT_VERSION}"
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
### Summary of the PR

The current output of the "Generate next docker tag" step is:

    Run echo "VERSION=$(./docker.sh print-next-version)" >> $GITHUB_ENV
    Next version to be published is:

The next version is not printed, because `$GITHUB_ENV` is loaded at the next step. So at this point we cannot access variables that we are setting in this step.

Use a temporary NEXT_VERSION variable where we save the next version to print it correctly.
