### PR TITLE
Build and install packages required by rutabaga_gfx

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -11,10 +11,15 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libssl-dev tzdata cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev \
     libdw-dev binutils-dev libiberty-dev make \
     cpio bc flex bison wget xz-utils fakeroot \
+    cmake cmake-data \
+    build-essential libjsoncpp25 librhash0 make \
     autoconf autoconf-archive automake libtool \
     libclang-dev iproute2 \
     libasound2 libasound2-dev \
     libepoxy0 libepoxy-dev \
+    libdrm2 libdrm-dev \
+    libglm-dev libstb-dev libc6-dev \
+    libvirglrenderer-dev libvirglrenderer1 \
     debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
 
 # cleanup
@@ -51,8 +56,25 @@ rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 
 cargo install cargo-llvm-cov
 
-# Install libgpiod and libpipewire (required by vhost-device crate)
+# Install aemu, gfxstream, libgpiod and libpipewire (required by vhost-device crate)
 pushd /opt
+git clone https://android.googlesource.com/platform/hardware/google/aemu
+pushd aemu
+git checkout v0.1.2-aemu-release
+cmake -DAEMU_COMMON_GEN_PKGCONFIG=ON \
+       -DAEMU_COMMON_BUILD_CONFIG=gfxstream \
+       -DENABLE_VKCEREAL_TESTS=OFF -B build
+cmake --build build -j
+cmake --install build
+popd
+rm -rf aemu
+git clone https://android.googlesource.com/platform/hardware/google/gfxstream
+pushd gfxstream
+git checkout v0.1.2-gfxstream-release
+meson setup host-build/
+meson install -C host-build/
+popd
+rm -rf gfxstream
 git clone --depth 1 --branch v2.0 https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
 pushd libgpiod
 ./autogen.sh --prefix=/usr && make && make install


### PR DESCRIPTION

### Summary of the PR

The vhost-device-gpu crate linked here
rust-vmm/vhost-device#668
contains rutabaga_gfx and the system library packages for rutabaga_gfx crate which is not available in the used ubuntu image, so install the neccessary packages that are available in ubuntu's repositories while for unavailable packages: build and install it manually.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
