### PR TITLE
Build and install additional packages for rutabaga_gfx

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -18,8 +18,8 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libasound2 libasound2-dev \
     libepoxy0 libepoxy-dev \
     libdrm2 libdrm-dev \
+    libgbm1 libgbm-dev libgles2 \
     libglm-dev libstb-dev libc6-dev \
-    libvirglrenderer-dev libvirglrenderer1 \
     debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
 
 # cleanup
@@ -56,7 +56,7 @@ rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 
 cargo install cargo-llvm-cov
 
-# Install aemu, gfxstream, libgpiod and libpipewire (required by vhost-device crate)
+# Install aemu, gfxstream, libgpiod, libpipewire and libvirglrenderer (required by vhost-device crate)
 pushd /opt
 git clone https://android.googlesource.com/platform/hardware/google/aemu
 pushd aemu
@@ -91,6 +91,14 @@ meson install -C builddir
 popd
 rm -rf pipewire-0.3.71
 rm pipewire-0.3.71.tar.gz
+git clone https://gitlab.freedesktop.org/virgl/virglrenderer.git
+pushd virglrenderer
+git checkout virglrenderer-1.0.1
+meson setup build
+ninja -C build
+ninja -C build install
+popd
+rm -rf virglrenderer
 popd
 
 # dbus-daemon expects this folder


### PR DESCRIPTION
### Summary of the PR

The vhost-device-gpu crate linked here
https://github.com/rust-vmm/vhost-device/pull/668
contains rutabaga_gfx and needs some packages and
virglrenderer greater that 1.0.0 which is not available
in the used ubuntu image, so install the neccessary
packages that are available in ubuntu's repositories and
for unavailable packages build and install it manually.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
