### PR TITLE
Update Rust Toolchain to 1.80.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-ARG RUST_TOOLCHAIN="1.75.0"
+ARG RUST_TOOLCHAIN="1.80.1"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"


### PR DESCRIPTION
With toolchain version >= 1.80 some crates had regressions due to stricter file descriptor ownership tracking in the standard library (e.g. tracking the same fd in multiple `File` objects, and thus resulting in multiple `close` calls for the same fd will now cause panics in the `drop` impl). We started getting fix-up PRs (https://github.com/rust-vmm/kvm-ioctls/pull/272), so update the CI to 1.80.1 to make sure we don't regress again after merging fixes.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
