### PR TITLE
github: Fix artifact attestation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.VERSION }}
+          subject-name: index.docker.io/${{ env.VERSION }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true
 
@@ -117,6 +117,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.VERSION }}-riscv
+          subject-name: index.docker.io/${{ env.VERSION }}-riscv
           subject-digest: ${{ steps.build-and-push-riscv.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
### Summary of the PR

Replace `env.REGISTRY` with `index.docker.io` as documentation [1] suggested, since it is empty.

[1] https://github.com/actions/attest-build-provenance#container-image

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
