### PR TITLE
github: Fix attest invalid image name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,10 +42,18 @@ jobs:
           username: ${{ secrets.DOCKER_ACCOUNT_ID }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Generate next docker tag
+      - name: Generate metadata for Docker
         # NOTE: The tag contains the full docker container name + tag as it is requested
         # by the build-and-push step.
         run: |
+          REGISTRY=$(./docker.sh print-registry)
+          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
+          echo "Registry to be published is: ${REGISTRY}"
+
+          IMAGE_NAME=$(./docker.sh print-image-name)
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "Image name to be published is: ${IMAGE_NAME}"
+
           NEXT_VERSION=$(./docker.sh print-next-version)
           echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
           echo "Next version to be published is: ${NEXT_VERSION}"
@@ -68,7 +76,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: index.docker.io/${{ env.VERSION }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true
 
@@ -95,8 +103,16 @@ jobs:
           username: ${{ secrets.DOCKER_ACCOUNT_ID }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Generate next docker tag
+      - name: Generate metadata for Docker
         run: |
+          REGISTRY=$(./docker.sh print-registry)
+          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
+          echo "Registry to be published is: ${REGISTRY}"
+
+          IMAGE_NAME=$(./docker.sh print-image-name)
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "Image name to be published is: ${IMAGE_NAME}"
+
           NEXT_VERSION=$(./docker.sh print-next-version)
           echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
           echo "Next version to be published is: ${NEXT_VERSION}"
@@ -117,6 +133,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: index.docker.io/${{ env.VERSION }}-riscv
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push-riscv.outputs.digest }}
           push-to-registry: true

--- a/docker.sh
+++ b/docker.sh
@@ -3,7 +3,8 @@ set -e
 ARCH=$(uname -m)
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-DOCKER_TAG=rustvmm/dev
+IMAGE_NAME=rustvmm/dev
+REGISTRY=index.docker.io
 
 # Get the latest published version. Returns a number.
 # If latest is v100, returns 100.
@@ -25,11 +26,19 @@ print_next_version() {
   echo "rustvmm/dev:v$(next_version)"
 }
 
+print_registry() {
+  echo ${REGISTRY}
+}
+
+print_image_name() {
+  echo ${IMAGE_NAME}
+}
+
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
   new_version=$(next_version)
-  new_tag=${DOCKER_TAG}:v${new_version}_$ARCH
+  new_tag=${IMAGE_NAME}:v${new_version}_$ARCH
   echo "$new_tag"
 }
 
@@ -49,7 +58,7 @@ build(){
 manifest(){
   latest_version=$(latest)
   new_version=$((latest_version + 1))
-  new_tag=${DOCKER_TAG}:v${new_version}
+  new_tag=${IMAGE_NAME}:v${new_version}
   docker manifest create \
         $new_tag \
         "${new_tag}_x86_64" \
@@ -75,6 +84,12 @@ case $1 in
     ;;
   "manifest")
     manifest;
+    ;;
+  "print-registry")
+    print_registry;
+    ;;
+  "print-image-name")
+    print_image_name;
     ;;
   "print-next-version")
     print_next_version;


### PR DESCRIPTION
### Summary of the PR

Strip tag from `IMAGE_NAME` used for attest, which should not contain column and tag. `IMAGE_NAME` is now specified explicitly to `rustvmm/dev`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
