### PR TITLE
riscv64: Fix VM network

### DIFF
--- a/riscv64/build_finalize.sh
+++ b/riscv64/build_finalize.sh
@@ -18,5 +18,6 @@ Host riscv-qemu
     StrictHostKeyChecking no
 EOF
 
-# Set `nameserver` for `resolv.conf`
-echo 'nameserver 8.8.8.8' > $ROOTFS_DIR/etc/resolv.conf
+# Set `nameserver` to `10.0.2.3` as QEMU User Networking documented.
+# See: https://wiki.qemu.org/Documentation/Networking
+echo 'nameserver 10.0.2.3' > $ROOTFS_DIR/etc/resolv.conf


### PR DESCRIPTION
### Summary of the PR

Change `nameserver` from `8.8.8.8` to `10.0.2.3` as QEMU User Networking (SLIRP)[1] documents.

[1] https://wiki.qemu.org/Documentation/Networking

Which addresses the network problem when cargo tries to fetch packages from `index.crates.io`.

Fixes: rust-vmm/kvm-bindings#106

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
