### PR TITLE
chore: Refactor toolchain versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:22.04
-ARG RUST_TOOLCHAIN="1.80.1"
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -23,7 +23,6 @@ RUN /opt/src/scripts/build.sh
 # ---------------------------------------------------------
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 AS rootfs_builder
 
-ARG RUST_TOOLCHAIN="1.75.0"
 ENV PATH="$PATH:/root/.cargo/bin"
 COPY build_container.sh /opt/src/scripts/build.sh
 RUN /opt/src/scripts/build.sh

--- a/build_container.sh
+++ b/build_container.sh
@@ -2,6 +2,7 @@
 set -ex
 
 ARCH=$(uname -m)
+RUST_TOOLCHAIN="1.80.1"
 
 apt-get update
 

--- a/riscv64/start_in_qemu.sh
+++ b/riscv64/start_in_qemu.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Minimum resources needed
-MIN_CORES=3
+MIN_CORES=4
 MIN_MEM=6
 DIVISOR=5
 

--- a/riscv64/start_in_qemu.sh
+++ b/riscv64/start_in_qemu.sh
@@ -30,7 +30,8 @@ cp -a $WORKDIR $ROOTFS_DIR/root
 HOST=riscv-qemu
 
 echo "Testing SSH connectivity to $HOST..."
-while ! ssh -o ConnectTimeout=3 $HOST exit; do
+while ! ssh -o ConnectTimeout=1 -q $HOST exit; do
+  sleep 10s
   echo "$HOST is not ready..."
 done
 


### PR DESCRIPTION
### Summary of the PR

- The `RUST_TOOLCHAIN` is defined separately in each `Dockerfile`, it's
easy to be left behind when trying to update rust toolchain version. By
moving into `build_containers.sh`, effectively eliminates the
possibility of having different rust toolchain version on different
architectures.
- Previous implementation would produce too much useless hint, which leads
to unnecessarily long log output.

This PR also updates rust toolchain version to 1.80.1 on riscv64.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
