### PR TITLE
Add apt dependencies for xen-sys CI tests

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -21,12 +21,19 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libdrm2 libdrm-dev \
     libgbm1 libgbm-dev libgles2 \
     libglm-dev libstb-dev libc6-dev \
-    debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus
+    debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus \
+    podman
 
 # `riscv64` specific dependencies
 if [ "$ARCH" == "riscv64" ]; then
     DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         openssh-server systemd init ifupdown busybox udev isc-dhcp-client
+fi
+
+# apt dependencies not available on `riscv64`
+if [ "$ARCH" != "riscv64" ]; then
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+        binutils-aarch64-linux-gnu
 fi
 
 # cleanup

--- a/docker.sh
+++ b/docker.sh
@@ -48,6 +48,7 @@ build_tag(){
 build(){
   new_tag=$(build_tag)
   docker build -t "$new_tag" \
+        --load \
         --build-arg GIT_BRANCH="${GIT_BRANCH}" \
         --build-arg GIT_COMMIT="${GIT_COMMIT}" \
         -f Dockerfile .


### PR DESCRIPTION
Install podman in order to be able to build and run containers inside
the CI container, and install binutils-aarch64-linux-gnu since the
aarch64-linux-gnu-objcopy binary is required to be able to create
aarch64 kernel ELFs for testing.

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>