### PR TITLE
Use `git sha1` instead of counter tagging

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
           # This is needed so that a manifest is created, and we can have the same
           # docker container on both x86_64 and arm64.
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.VERSION }}
+          tags: ${{ env.VERSION }},${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -125,7 +125,7 @@ jobs:
           file: Dockerfile.riscv64
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
-          tags: ${{ env.VERSION }}-riscv
+          tags: ${{ env.VERSION }}-riscv,${{ env.IMAGE_NAME }}:latest-riscv
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/build_container.sh
+++ b/build_container.sh
@@ -4,6 +4,12 @@ set -ex
 ARCH=$(uname -m)
 RUST_TOOLCHAIN="1.83.0"
 
+# See: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
+if [ "$ARCH" == "aarch64" ]; then
+    rm /var/lib/dpkg/info/libc-bin.*
+    DEBIAN_FRONTEND="noninteractive" apt-get clean
+fi
+
 apt-get update
 
 # DEBIAN_FRONTEND is set for tzdata.

--- a/docker.sh
+++ b/docker.sh
@@ -23,7 +23,7 @@ next_version() {
 }
 
 print_next_version() {
-  echo "rustvmm/dev:v$(next_version)"
+  echo "${IMAGE_NAME}:v$(next_version)"
 }
 
 print_registry() {
@@ -37,8 +37,7 @@ print_image_name() {
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
-  new_version=$(next_version)
-  new_tag=${IMAGE_NAME}:v${new_version}_$ARCH
+  new_tag=$(print_next_version)_$ARCH
   echo "$new_tag"
 }
 
@@ -57,9 +56,7 @@ build(){
 
 # Creates and pushes a manifest for a new version
 manifest(){
-  latest_version=$(latest)
-  new_version=$((latest_version + 1))
-  new_tag=${IMAGE_NAME}:v${new_version}
+  new_tag=$(print_next_version)
   docker manifest create \
         $new_tag \
         "${new_tag}_x86_64" \

--- a/docker.sh
+++ b/docker.sh
@@ -6,24 +6,12 @@ GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 IMAGE_NAME=rustvmm/dev
 REGISTRY=index.docker.io
 
-# Get the latest published version. Returns a number.
-# If latest is v100, returns 100.
-# If latest for riscv64 is v100-riscv, returns 100.
-# This works as long as we have less than 100 tags because we set the page size to 100,
-# once we have more than that this script needs to be updated.
-latest(){
-  curl -L -s 'https://registry.hub.docker.com/v2/repositories/rustvmm/dev/tags?page_size=100'| \
-    jq '."results"[]["name"]' |  sed 's/"//g' | cut -c 2- | grep -E "^[0-9]+" | sort -n | tail -1
-}
-
 next_version() {
-    latest_version=$(latest)
-    new_version=$((latest_version + 1))
-    echo "$new_version"
+    echo "$(git show -s --format=%h)"
 }
 
 print_next_version() {
-  echo "${IMAGE_NAME}:v$(next_version)"
+  echo "${IMAGE_NAME}:g$(next_version)"
 }
 
 print_registry() {
@@ -42,8 +30,6 @@ build_tag(){
 }
 
 # Build a new docker version.
-# It will build a new docker image with tag latest version + 1
-# and will alias it with "latest" tag.
 build(){
   new_tag=$(build_tag)
   docker build -t "$new_tag" \

--- a/docker.sh
+++ b/docker.sh
@@ -25,7 +25,11 @@ print_image_name() {
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
-  new_tag=$(print_next_version)_$ARCH
+  if [ "$ARCH" == "riscv64" ]; then
+    new_tag=$(print_next_version)-riscv
+  else
+    new_tag=$(print_next_version)_$ARCH
+  fi
   echo "$new_tag"
 }
 


### PR DESCRIPTION
### Summary of the PR

- docker.sh: Reuse code as much as possible
- docker.sh: Replace counter tagging with git sha1:

  We were using `vXX` counter tagging till `v49` for x86_64 and aarch64,
and `v49-riscv` for riscv64. And we have separated riscv64 from the
other two to another job due to insufficient Github Action time limit
(if the job failed to complete in 6 hours, it will be canceled), which
end up of having two jobs. If the x86_64 and aarch64 job are finished
and images are published in vN, while riscv64 job fails in that run,
restarting the riscv64 job will result an absence of vN and a presence
of v(N+1). So we decided to move on to git sha1 tagging strategy.

  Remove `latest` function and `vXX` counter tagging, and use output of

  ```console
  git show -s --format=%h
  ```

  as the tag of images built per PR for publishing.

- docker.sh: Introduce RISC-V support for manual operations
- ci: Add latest tag for ease of use

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
