### PR TITLE
Upgrade ubuntu:22.04 to ubuntu:24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,27 +1,27 @@
 # Compile QEMU 9.0.2
 # ---------------------------------------------------------
-FROM ubuntu:22.04 AS qemu_builder
+FROM ubuntu:24.04 AS qemu_builder
 
 COPY riscv64/build_qemu_system_riscv64.sh /opt/src/scripts/build.sh
 RUN /opt/src/scripts/build.sh
 
 # Compile kernel 6.10 since we need AIA drivers
 # ---------------------------------------------------------
-FROM ubuntu:22.04 AS kernel_builder
+FROM ubuntu:24.04 AS kernel_builder
 
 COPY riscv64/build_kernel.sh /opt/src/scripts/build.sh
 RUN /opt/src/scripts/build.sh
 
 # Compile OpenSBI
 # ---------------------------------------------------------
-FROM ubuntu:22.04 AS opensbi_builder
+FROM ubuntu:24.04 AS opensbi_builder
 
 COPY riscv64/build_opensbi.sh /opt/src/scripts/build.sh
 RUN /opt/src/scripts/build.sh
 
 # Build rootfs with sshd and Rust related packages ready
 # ---------------------------------------------------------
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 AS rootfs_builder
+FROM --platform=linux/riscv64 riscv64/ubuntu:24.04 AS rootfs_builder
 
 ENV PATH="$PATH:/root/.cargo/bin"
 COPY build_container.sh /opt/src/scripts/build.sh
@@ -29,7 +29,7 @@ RUN /opt/src/scripts/build.sh
 
 # Finalize
 # ---------------------------------------------------------
-FROM ubuntu:22.04 AS final
+FROM ubuntu:24.04 AS final
 
 ARG OUTPUT=/output
 ARG QEMU_DIR=/opt/qemu

--- a/build_container.sh
+++ b/build_container.sh
@@ -126,7 +126,7 @@ if [ "$ARCH" != "riscv64" ]; then
 fi
 
 # dbus-daemon expects this folder
-mkdir /run/dbus
+mkdir -p /run/dbus
 
 # `riscv64` specific, which setup the rootfs for `riscv64` VM to execute actual
 # RISC-V tests through prepared ssh server.

--- a/build_container.sh
+++ b/build_container.sh
@@ -22,7 +22,7 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     build-essential libjsoncpp25 librhash0 make \
     autoconf autoconf-archive automake libtool \
     libclang-dev iproute2 \
-    libasound2 libasound2-dev \
+    libasound2t64 libasound2-dev \
     libepoxy0 libepoxy-dev \
     libdrm2 libdrm-dev \
     libgbm1 libgbm-dev libgles2 \

--- a/build_container.sh
+++ b/build_container.sh
@@ -4,12 +4,6 @@ set -ex
 ARCH=$(uname -m)
 RUST_TOOLCHAIN="1.83.0"
 
-# See: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin
-if [ "$ARCH" == "aarch64" ]; then
-    rm /var/lib/dpkg/info/libc-bin.*
-    DEBIAN_FRONTEND="noninteractive" apt-get clean
-fi
-
 apt-get update
 
 # DEBIAN_FRONTEND is set for tzdata.

--- a/riscv64/build_finalize.sh
+++ b/riscv64/build_finalize.sh
@@ -13,7 +13,7 @@ echo 'tmpfs /tmp tmpfs rw,nosuid,nodev,size=524288k,nr_inodes=204800 0 0' >> $RO
 
 # Setup container ssh config
 yes "" | ssh-keygen -P ""
-cat /root/.ssh/id_rsa.pub > $ROOTFS_DIR/root/.ssh/authorized_keys
+cat /root/.ssh/*.pub > $ROOTFS_DIR/root/.ssh/authorized_keys
 cat > /root/.ssh/config << EOF
 Host riscv-qemu
     HostName localhost


### PR DESCRIPTION
### Summary of the PR

Our downstream communities (cloud-hypervisor, firecracker, kata-containers and etc.) are upgrading to Ubuntu 24.04, propose to catch up.

- base image: Upgrade from Ubuntu 22.04 to 24.04
- ci: Remove work around for aarch64
- build_container: Add p flag while mkdir for dbus
- riscv64: Replace id_rsa.pub with *.pub

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
