### PR TITLE
build_container: Allow pip to install system-wide

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -51,7 +51,8 @@ fi
 
 # Allow pip to install packages system wide
 rm /usr/lib/python3.*/EXTERNALLY-MANAGED
-pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
+pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout
+apt purge -y python3-pip
 
 # Install rustup and a fixed version of Rust.
 curl https://sh.rustup.rs -sSf | sh -s -- \

--- a/build_container.sh
+++ b/build_container.sh
@@ -49,6 +49,8 @@ if [ "$ARCH" != "riscv64" ]; then
     popd
 fi
 
+# Allow pip to install packages system wide
+rm /usr/lib/python3.*/EXTERNALLY-MANAGED
 pip3 install --no-cache-dir pytest pexpect boto3 pytest-timeout && apt purge -y python3-pip
 
 # Install rustup and a fixed version of Rust.


### PR DESCRIPTION
### Summary of the PR

Found in https://github.com/rust-vmm/rust-vmm-container/actions/runs/13650154708/job/38156682477#step:7:2290.

We are having `error: externally-managed-environment` after upgrading to ubuntu:24.04. Remove `EXTERNALLY-MANAGED` file to allow pip to install packages system-wide.

And even if we have `set -e`, if `pip install` fails, the script goes on because we use the && operator.

Avoid this to make sure that we discover any errors with `pip install`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
