### PR TITLE
Add windows docker build script

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,10 @@ jobs:
           echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
           echo "Next version to be published is: ${NEXT_VERSION}"
 
+          RUST_TOOLCHAIN=$(./docker.sh print-rust-toolchain)
+          echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
+          echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
+
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v6
@@ -72,6 +76,7 @@ jobs:
           # docker container on both x86_64 and arm64.
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.VERSION }},${{ env.IMAGE_NAME }}:latest
+          build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -120,6 +125,10 @@ jobs:
           echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
           echo "Next version to be published is: ${NEXT_VERSION}"
 
+          RUST_TOOLCHAIN=$(./docker.sh print-rust-toolchain)
+          echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
+          echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
+
       - name: Build and push Docker image for RISC-V
         id: build-and-push-riscv
         uses: docker/build-push-action@v6
@@ -129,6 +138,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
           tags: ${{ env.VERSION }}-riscv,${{ env.IMAGE_NAME }}:latest-riscv
+          build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG RUST_TOOLCHAIN
+ENV RUST_TOOLCHAIN=${RUST_TOOLCHAIN}
 # Adding rust binaries to PATH.
 ENV PATH="$PATH:/root/.cargo/bin"
 

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -23,6 +23,8 @@ RUN /opt/src/scripts/build.sh
 # ---------------------------------------------------------
 FROM --platform=linux/riscv64 riscv64/ubuntu:24.04 AS rootfs_builder
 
+ARG RUST_TOOLCHAIN
+ENV RUST_TOOLCHAIN=${RUST_TOOLCHAIN}
 ENV PATH="$PATH:/root/.cargo/bin"
 COPY build_container.sh /opt/src/scripts/build.sh
 RUN /opt/src/scripts/build.sh

--- a/Dockerfile.windows.x86_64
+++ b/Dockerfile.windows.x86_64
@@ -7,7 +7,6 @@ ARG RUST_TOOLCHAIN
 FROM mcr.microsoft.com/windows/servercore:$WIN_VER
 
 ENV chocolateyUseWindowsCompression "true"
-ENV RUST_TOOLCHAIN="1.46.0"
 
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 ADD https://win.rustup.rs/x86_64 C:\TEMP\rustup-init.exe

--- a/Dockerfile.windows.x86_64
+++ b/Dockerfile.windows.x86_64
@@ -7,6 +7,8 @@ ARG RUST_TOOLCHAIN
 FROM mcr.microsoft.com/windows/servercore:$WIN_VER
 
 ENV chocolateyUseWindowsCompression "true"
+# Set Chocolatey version to 1.4.0 to avoid .NET Framework 4.8 dependency
+ENV chocolateyVersion="1.4.0"
 
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 ADD https://win.rustup.rs/x86_64 C:\TEMP\rustup-init.exe

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Example of running cargo build on the kvm crate:
     Finished `release` profile [optimized] target(s) in 6.34s
 ```
 
+For Windows users (ensure Docker Desktop is in Linux containers mode):
+```powershell
+> git clone https://github.com/rust-vmm/kvm.git
+> cd kvm
+> docker run --volume "${PWD}:/kvm" `
+    rustvmm/dev:latest `
+    /bin/bash -c "cd /kvm && cargo build --release"
+```
 ## Testing Changes locally with the Container Image
 
 When we modify the container to install new dependencies, we may need to 
@@ -74,6 +82,28 @@ Since you've mounted the host's current directory ($(pwd)) to `/workdir` in
 the container, any files in the current working directory on the host will be
 accessible in the `/workdir` directory inside the container.
 
+For Windows (ensure Docker Desktop is in Linux containers mode):
+```powershell
+> cd rust-vmm-container
+> .\docker.ps1 build
+
+# Example output: Build completed for rustvmm/dev:gb607c2b_x86_64
+
+# Test the container using the tag from the build output
+> docker run -it --rm `
+    --volume "${PWD}:/path/to/workdir" `
+    --workdir /path/to/workdir `
+    rustvmm/dev:gb607c2b_x86_64
+```
+
+Note: Unlike Linux, Windows doesn't have direct access to KVM, so the `--device=/dev/kvm` and `--privileged` flags are not needed.
+
+Note: If you want to build a Windows container instead, you can switch Docker Desktop to "Windows containers" mode and run:
+```powershell
+> cd rust-vmm-container
+> .\docker.ps1 build   # This will automatically use Dockerfile.windows.x86_64
+```
+
 ## Publishing a New Version
 
 A new container version is published for each PR merged to main that adds
@@ -105,6 +135,18 @@ On an `aarch64` platform:
 > cd rust-vmm-dev-container
 > ./docker.sh build
 > ./docker.sh publish
+```
+
+On Windows (ensure Docker Desktop is in Linux containers mode):
+
+```powershell
+> cd rust-vmm-container
+> .\docker.ps1 build
+> .\docker.ps1 publish
+
+
+# To check if Docker is in Linux containers mode:
+> docker version --format '{{.Server.Os}}'  # Should output 'linux'
 ```
 
 You will need to redo all steps on an `x86_64` platform so the containers are

--- a/build_container.sh
+++ b/build_container.sh
@@ -2,7 +2,6 @@
 set -ex
 
 ARCH=$(uname -m)
-RUST_TOOLCHAIN="1.85.0"
 
 apt-get update
 

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,4 @@
+IMAGE_NAME=rustvmm/dev
+REGISTRY=index.docker.io
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/docker.env
+++ b/docker.env
@@ -2,3 +2,4 @@ IMAGE_NAME=rustvmm/dev
 REGISTRY=index.docker.io
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RUST_TOOLCHAIN="1.85.0"

--- a/docker.ps1
+++ b/docker.ps1
@@ -1,0 +1,100 @@
+param(
+ [Parameter(Mandatory=$false)]
+ [string]$Command
+)
+$ErrorActionPreference = "Stop"
+Get-Content docker.env | Where-Object { $_ -match '^([^#][^=]+)=(.+)$' } | ForEach-Object {
+    if ($matches[2] -match '\$\((.*)\)') {
+        $cmdOutput = Invoke-Expression $matches[1]
+        Set-Variable -Name $matches[1].Trim() -Value $cmdOutput -Scope Script
+    } else {
+        Set-Variable -Name $matches[1].Trim() -Value $matches[2].Trim() -Scope Script
+    }
+}
+$ARCH = "x86_64"  # Explicitly set the architecture
+
+function Next-Version {
+    return (git show -s --format=%h)
+}
+
+function Get-FullVersion {
+    $version = Next-Version
+    return "${IMAGE_NAME}:g${version}"
+}
+
+function Print-NextVersion {
+    Write-Output (Get-FullVersion)
+}
+
+function Print-Registry {
+    Write-Output $REGISTRY
+}
+
+function Print-ImageName {
+    Write-Output $IMAGE_NAME
+}
+
+function Build-Tag {
+    return "$(Get-FullVersion)_$ARCH"
+}
+
+function Check-ExitCode {
+    param (
+        [int]$ExitCode,
+        [string]$Message
+    )
+    
+    if ($ExitCode -ne 0) {
+        Write-Error $Message
+        exit $ExitCode
+    }
+}
+
+function Build-Container {
+    # Check if running in Linux or Windows container mode
+    $containerInfo = docker version --format '{{.Server.Os}}'
+    $dockerfile = if ($containerInfo -eq "linux") {
+        "Dockerfile"
+    } else {
+        "Dockerfile.windows.x86_64"
+    }
+    
+    # Build the container and check for failures
+    $tag = Build-Tag
+    Write-Host "Building using $dockerfile in $containerInfo container mode..."
+    
+    docker build -t $tag `
+        --build-arg GIT_BRANCH=$GIT_BRANCH `
+        --build-arg GIT_COMMIT=$GIT_COMMIT `
+        --build-arg RUST_TOOLCHAIN=$RUST_TOOLCHAIN `
+        -f $dockerfile .
+    Check-ExitCode $LASTEXITCODE "Build failed with exit code $LASTEXITCODE"
+    Write-Host "Build completed for $tag"
+}
+
+function Publish-Container {
+    $tag = Build-Tag
+    Write-Host "Publishing $tag to dockerhub"
+    
+    # Check if image exists locally
+    $imageExists = docker image inspect $tag 2>$null
+    Check-ExitCode $LASTEXITCODE "Image $tag not found locally. Please run 'build' first."
+
+    # Attempt to push
+    docker push $tag
+    Check-ExitCode $LASTEXITCODE "Failed to publish $tag"
+    Write-Host "Successfully published $tag"
+}
+
+# Handle commands
+switch ($Command) {
+    "build" { Build-Container }
+    "publish" { Publish-Container }
+    "print-registry" { Print-Registry }
+    "print-image-name" { Print-ImageName }
+    "print-next-version" { Print-NextVersion }
+    default { 
+        Write-Host "Command $Command not supported. Try with 'publish', 'build', or 'print-next-version'." 
+        exit 1
+    }
+}

--- a/docker.sh
+++ b/docker.sh
@@ -19,6 +19,10 @@ print_image_name() {
   echo ${IMAGE_NAME}
 }
 
+print_rust_toolchain() {
+  echo ${RUST_TOOLCHAIN}
+}
+
 # Builds the tag for the newest versions. It needs the last published version number.
 # Returns a valid docker tag.
 build_tag(){
@@ -37,6 +41,7 @@ build(){
         --load \
         --build-arg GIT_BRANCH="${GIT_BRANCH}" \
         --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+        --build-arg RUST_TOOLCHAIN="${RUST_TOOLCHAIN}" \
         -f Dockerfile .
   echo "Build completed for $new_tag"
 }
@@ -78,6 +83,9 @@ case $1 in
     ;;
   "print-next-version")
     print_next_version;
+    ;;
+    "print-rust-toolchain")
+    print_rust_toolchain;
     ;;
   *)
    echo "Command $1 not supported. Try with 'publish', 'build', 'manifest' or 'print-next-version'. ";

--- a/docker.sh
+++ b/docker.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -e
+source "$(dirname "$0")/docker.env"
 ARCH=$(uname -m)
-GIT_COMMIT=$(git rev-parse HEAD)
-GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-IMAGE_NAME=rustvmm/dev
-REGISTRY=index.docker.io
 
 next_version() {
     echo "$(git show -s --format=%h)"


### PR DESCRIPTION
### Summary of the PR

- Added `docker.ps1` to enable building the container using PowerShell with the following command:
  ```powershell
  .\docker.ps1 build
  ```
  And publishing the container using:
  ```powershell
  .\docker.ps1 publish
  ```
 as in `docker.sh` to resolve https://github.com/rust-vmm/rust-vmm-container/issues/49 (Note: didn't update the manifest in `docker.sh`)

- Modified `.github/workflows/docker-publish.yml` to: Add `build-windows` job for Windows containers.
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.