### PR TITLE
build_container: Install rsync in image

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -8,7 +8,7 @@ apt-get update
 
 # DEBIAN_FRONTEND is set for tzdata.
 DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
-    curl gcc musl-tools git python3 python3-pip shellcheck \
+    curl gcc musl-tools git python3 python3-pip shellcheck rsync \
     libssl-dev tzdata cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev \
     libdw-dev binutils-dev libiberty-dev make \
     cpio bc flex bison wget xz-utils fakeroot \


### PR DESCRIPTION
### Summary of the PR

`rsync` is required for installing kernel headers, which will be used in `seccompiler` crate to generate syscall tables.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
