### PR TITLE
install rustup targets for MacOS and Windows 

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -77,6 +77,12 @@ if [ "$ARCH" != "riscv64" ]; then
     rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 fi
 
+# The below are only used for compile-testing via cargo check.
+# It suffices to do that on _one_ architecture.
+if [ "$ARCH" == "x86_64" ]; then
+    rustup target add aarch64-apple-darwin x86_64-pc-windows-gnu
+fi
+
 cargo install cargo-llvm-cov
 
 # Install the codecov.io uploader. Not available on riscv64, so skip there

--- a/build_container.sh
+++ b/build_container.sh
@@ -22,7 +22,6 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libglm-dev libstb-dev libc6-dev \
     debhelper-compat libdbus-1-dev libglib2.0-dev meson ninja-build dbus \
     libvirglrenderer1 libvirglrenderer-dev pipewire libpipewire-0.3-dev \
-    lsof \
     podman
 
 # `riscv64` specific dependencies


### PR DESCRIPTION
### Summary of the PR

Some of the rust-vmm crates (such as vmm-sys-util and vm-memory) have
somewhat rudimentary support for MacOS and Windows. While our CI does
not have the means to test these platforms (the rust-vmm CI runners are
linux-only), it can at least do some simple compile testing using `cargo
check` (as long as we do not have any build dependencies that try to
compile native libraries). For this, install the required cargo targets
into the docker container, such that crates that wish to do such compile
testing can specify such additional tests in their custom tests
pipelines.

While we're here, also revert #135, because we ended up not needing the utility.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
