### PR TITLE
Add cargo-all-features to docker container

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -98,6 +98,8 @@ if [ "$ARCH" != "riscv64" ]; then
     popd
 fi
 
+cargo install cargo-all-features
+
 # Install some dependencies required by vhost-device crates but not available
 # in Ubuntu repos.
 # Some of these do not support riscv64, since vhost-device crates do not


### PR DESCRIPTION
Some crates have a myriad of features, and it is very easy to
accidentally mess up imports in a way that `cargo check --all-features`
works, but only compiling with only a subset of features breaks. For
this scenario, cargo check-all-features can help, as it will attempt to
compile all feature permutations.

We can even add this to the default CI, even for crates like vhost that
have incompatible features, due to cargo-all-features allowing the
elimination of incompatible features from the test matrix [1].

Some usecases where this could have been helpful is in vm-memory, where
we have tens of feature permutations, and some of them invariably get
broken regularly [2], or in crates that have no-std support that is
offered via an opt-out 'std' feature [3]

[1]: https://crates.io/crates/cargo-all-features#options
[2]: https://github.com/rust-vmm/vm-memory/pull/350
[3]: https://github.com/rust-vmm/vm-allocator/pull/107

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
