### PR TITLE
build_container: install at least cargo-audit 0.22

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -63,8 +63,10 @@ curl https://sh.rustup.rs -sSf | sh -s -- \
 # Install cargo tools.
 # Use `git` executable to avoid OOM on arm64:
 # https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
+#
+# cargo-audit 0.22 is the first version that can parse cvss 4.0 scores
 cargo --config "net.git-fetch-with-cli = true" \
-    install critcmp cargo-audit cargo-fuzz
+    install critcmp "cargo-audit@>=0.22.0" cargo-fuzz
 rm -rf /root/.cargo/registry/
 
 # Install nightly (needed for fuzzing)


### PR DESCRIPTION
### Summary of the PR

cargo-audit 0.22 is the first version that can parse cvss 4.0 scores and avoid the following error in our pipelines:
  $ cargo audit -q --deny warnings
  error: error loading advisory database: parse error: TOML parse error at line 8, column 8
    |
  8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  unsupported CVSS version: 4.0

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
