### PR TITLE
s390x: Introduce s390x CI container

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,9 +85,20 @@ jobs:
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true
 
-  build-riscv:
-
+  build-alt-arch:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: riscv
+            dockerfile: Dockerfile.riscv64
+            tag_suffix: riscv
+            push_attestation: true
+          - arch: s390x
+            dockerfile: Dockerfile.s390x
+            tag_suffix: s390x
+            push_attestation: false
+
     permissions:
       packages: write
       contents: read
@@ -112,29 +123,25 @@ jobs:
         run: |
           REGISTRY=$(./docker.sh print-registry)
           echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
-          echo "Registry to be published is: ${REGISTRY}"
 
           IMAGE_NAME=$(./docker.sh print-image-name)
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
-          echo "Image name to be published is: ${IMAGE_NAME}"
 
           NEXT_VERSION=$(./docker.sh print-next-version)
           echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
-          echo "Next version to be published is: ${NEXT_VERSION}"
 
           RUST_TOOLCHAIN=$(./docker.sh print-rust-toolchain)
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
-          echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
 
-      - name: Build and push Docker image for RISC-V
-        id: build-and-push-riscv
+      - name: Build and push Docker image for ${{ matrix.arch }}
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.riscv64
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
-          tags: ${{ env.VERSION }}-riscv,${{ env.IMAGE_NAME }}:latest-riscv
+          tags: ${{ env.VERSION }}-${{ matrix.tag_suffix }},${{ env.IMAGE_NAME }}:latest-${{ matrix.tag_suffix }}
           build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -144,67 +151,5 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build-and-push-riscv.outputs.digest }}
-          push-to-registry: true
-
-  build-s390x:
-
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
-
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_ACCOUNT_ID }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      - name: Generate metadata for Docker
-        run: |
-          REGISTRY=$(./docker.sh print-registry)
-          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
-          echo "Registry to be published is: ${REGISTRY}"
-
-          IMAGE_NAME=$(./docker.sh print-image-name)
-          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
-          echo "Image name to be published is: ${IMAGE_NAME}"
-
-          NEXT_VERSION=$(./docker.sh print-next-version)
-          echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
-          echo "Next version to be published is: ${NEXT_VERSION}"
-
-          RUST_TOOLCHAIN=$(./docker.sh print-rust-toolchain)
-          echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
-          echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
-
-      - name: Build and push Docker image for s390x
-        id: build-and-push-s390x
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.s390x
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64
-          tags: ${{ env.VERSION }}-s390x,${{ env.IMAGE_NAME }}:latest-s390x
-          build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Generate artifact attestation
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build-and-push-s390x.outputs.digest }}
-          push-to-registry: false
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: ${{ matrix.push_attestation }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -146,3 +146,65 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push-riscv.outputs.digest }}
           push-to-registry: true
+
+  build-s390x:
+
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_ACCOUNT_ID }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Generate metadata for Docker
+        run: |
+          REGISTRY=$(./docker.sh print-registry)
+          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
+          echo "Registry to be published is: ${REGISTRY}"
+
+          IMAGE_NAME=$(./docker.sh print-image-name)
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "Image name to be published is: ${IMAGE_NAME}"
+
+          NEXT_VERSION=$(./docker.sh print-next-version)
+          echo "VERSION=${NEXT_VERSION}" >> $GITHUB_ENV
+          echo "Next version to be published is: ${NEXT_VERSION}"
+
+          RUST_TOOLCHAIN=$(./docker.sh print-rust-toolchain)
+          echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
+          echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
+
+      - name: Build and push Docker image for s390x
+        id: build-and-push-s390x
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64
+          tags: ${{ env.VERSION }}-s390x,${{ env.IMAGE_NAME }}:latest-s390x
+          build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-and-push-s390x.outputs.digest }}
+          push-to-registry: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,9 +85,18 @@ jobs:
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true
 
-  build-riscv:
-
+  build-alt-arch:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: riscv
+            dockerfile: Dockerfile.riscv64
+            tag_suffix: riscv
+          - arch: s390x
+            dockerfile: Dockerfile.s390x
+            tag_suffix: s390x
+
     permissions:
       packages: write
       contents: read
@@ -126,15 +135,15 @@ jobs:
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" >> $GITHUB_ENV
           echo "Rust toolchain used is: ${RUST_TOOLCHAIN}"
 
-      - name: Build and push Docker image for RISC-V
-        id: build-and-push-riscv
+      - name: Build and push Docker image for ${{ matrix.arch }}
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.riscv64
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
-          tags: ${{ env.VERSION }}-riscv,${{ env.IMAGE_NAME }}:latest-riscv
+          tags: ${{ env.VERSION }}-${{ matrix.tag_suffix }},${{ env.IMAGE_NAME }}:latest-${{ matrix.tag_suffix }}
           build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -144,5 +153,5 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build-and-push-riscv.outputs.digest }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,0 +1,26 @@
+# Build rootfs with sshd and Rust related packages ready
+# ---------------------------------------------------------
+FROM --platform=linux/s390x s390x/ubuntu:24.04 AS rootfs_builder
+
+ARG RUST_TOOLCHAIN
+ENV RUST_TOOLCHAIN=${RUST_TOOLCHAIN}
+ENV PATH="$PATH:/root/.cargo/bin"
+COPY build_container.sh /opt/src/scripts/build.sh
+RUN /opt/src/scripts/build.sh
+
+# Finalize
+# ---------------------------------------------------------
+FROM ubuntu:24.04 AS final
+
+ARG ROOTFS_DIR=/opt/rootfs
+
+COPY --from=rootfs_builder / $ROOTFS_DIR
+
+COPY s390x/build_finalize.sh /opt/src/scripts/finalize.sh
+RUN /opt/src/scripts/finalize.sh
+
+ENV ROOTFS_DIR=$ROOTFS_DIR WORKDIR=/workdir
+
+# Start qemu-system-s390x as a background process
+COPY s390x/start_in_qemu.sh /opt/src/scripts/start.sh
+ENTRYPOINT ["/opt/src/scripts/start.sh"]

--- a/build_container.sh
+++ b/build_container.sh
@@ -25,14 +25,22 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     podman libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
     gstreamer1.0-plugins-base gstreamer1.0-plugins-good 
 
-# `riscv64` specific dependencies
-if [ "$ARCH" == "riscv64" ]; then
+# `riscv64` and `s390x` specific dependencies
+if [ "$ARCH" == "riscv64" ] || [ "$ARCH" == "s390x" ]; then
     DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         openssh-server systemd init ifupdown busybox udev isc-dhcp-client
 fi
 
-# apt dependencies not available on `riscv64`
-if [ "$ARCH" != "riscv64" ]; then
+# `s390x` specific dependencies
+if [ "$ARCH" == "s390x" ]; then
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+        linux-image-generic initramfs-tools
+    echo -e '9p\n9pnet\n9pnet_virtio' >> /etc/initramfs-tools/modules
+    update-initramfs -c -k all
+fi
+
+# apt dependencies not available on `riscv64` and `s390x`
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         binutils-aarch64-linux-gnu
 fi
@@ -41,8 +49,8 @@ fi
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # help musl-gcc find linux headers
-# Skip on `riscv64` for now
-if [ "$ARCH" != "riscv64" ]; then
+# Skip on `riscv64` and `s390x` for now
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /usr/include/$ARCH-linux-musl 
     ln -s ../$ARCH-linux-gnu/asm asm 
     ln -s ../linux linux 
@@ -76,7 +84,7 @@ rustup component add llvm-tools-preview  # needed for coverage
 
 # Install other rust targets.
 # Skip on `riscv64` for now
-if [ "$ARCH" != "riscv64" ]; then
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 fi
 
@@ -88,8 +96,8 @@ fi
 
 cargo install cargo-llvm-cov
 
-# Install the codecov.io uploader. Not available on riscv64, so skip there
-if [ "$ARCH" != "riscv64" ]; then
+# Install the codecov.io uploader. Not available on riscv64 and s390x, so skip there
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /usr/local/bin
     if [ "$ARCH" = "x86_64" ]; then
         curl -O https://uploader.codecov.io/latest/linux/codecov
@@ -104,9 +112,9 @@ cargo install cargo-all-features
 
 # Install some dependencies required by vhost-device crates but not available
 # in Ubuntu repos.
-# Some of these do not support riscv64, since vhost-device crates do not
+# Some of these do not support riscv64 or s390x, since vhost-device crates do not
 # support riscv64 too, let's skip them for now.
-if [ "$ARCH" != "riscv64" ]; then
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /opt
 
     # required by vhost-device-gpu
@@ -158,9 +166,9 @@ fi
 # dbus-daemon expects this folder
 mkdir -p /run/dbus
 
-# `riscv64` specific, which setup the rootfs for `riscv64` VM to execute actual
-# RISC-V tests through prepared ssh server.
-if [ "$ARCH" == "riscv64" ]; then
+# QEMU specific, which setup the rootfs for `riscv64` and `s390x` VM to execute actual
+# target ARCH tests through prepared ssh server.
+if [ "$ARCH" == "riscv64" ] ||  [ "$ARCH" == "s390x" ] ; then
     # Set passwd for debugging
     echo 'root:rustvmm' | chpasswd
     # Allow root login
@@ -170,11 +178,11 @@ if [ "$ARCH" == "riscv64" ]; then
     systemctl enable ssh
     mkdir -p /root/.ssh
     # Setup network
-    echo $'auto lo\niface lo inet loopback\n\nauto eth0\niface eth0 inet dhcp\n' > /etc/network/interfaces
+    echo $'auto lo\niface lo inet loopback\n\nauto eth0\niface eth0 inet dhcp\n\nauto enc1\niface enc1 inet dhcp\n' > /etc/network/interfaces
 fi
 
-# Install kani in x86 and arm. Not available on riscv64, so skip there
-if [ "$ARCH" != "riscv64" ]; then
+# Install kani in x86 and arm. Not available on riscv64 and s390x, so skip there
+if [ "$ARCH" != "riscv64" ] &&  [ "$ARCH" != "s390x" ] ; then
     cargo install --locked kani-verifier
     cargo kani setup
 fi

--- a/build_container.sh
+++ b/build_container.sh
@@ -27,14 +27,22 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     podman libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
     gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
-# `riscv64` specific dependencies
-if [ "$ARCH" == "riscv64" ]; then
+# `riscv64` and `s390x` specific dependencies
+if [ "$ARCH" == "riscv64" ] || [ "$ARCH" == "s390x" ]; then
     DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         openssh-server systemd init ifupdown busybox udev isc-dhcp-client
 fi
 
-# apt dependencies not available on `riscv64`
-if [ "$ARCH" != "riscv64" ]; then
+# `s390x` specific dependencies
+if [ "$ARCH" == "s390x" ]; then
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+        linux-image-generic initramfs-tools
+    echo -e '9p\n9pnet\n9pnet_virtio' >> /etc/initramfs-tools/modules
+    update-initramfs -c -k all
+fi
+
+# apt dependencies not available on `riscv64` and `s390x`
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         binutils-aarch64-linux-gnu
 fi
@@ -43,8 +51,8 @@ fi
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # help musl-gcc find linux headers
-# Skip on `riscv64` for now
-if [ "$ARCH" != "riscv64" ]; then
+# Skip on `riscv64` and `s390x` for now
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /usr/include/$ARCH-linux-musl 
     ln -s ../$ARCH-linux-gnu/asm asm 
     ln -s ../linux linux 
@@ -77,8 +85,8 @@ rustup component add miri rust-src --toolchain nightly
 rustup component add llvm-tools-preview  # needed for coverage
 
 # Install other rust targets.
-# Skip on `riscv64` for now
-if [ "$ARCH" != "riscv64" ]; then
+# Skip on `riscv64` and `s390x` for now
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     rustup target add $ARCH-unknown-linux-musl $ARCH-unknown-none
 fi
 
@@ -90,8 +98,8 @@ fi
 
 cargo install cargo-llvm-cov
 
-# Install the codecov.io uploader. Not available on riscv64, so skip there
-if [ "$ARCH" != "riscv64" ]; then
+# Install the codecov.io uploader. Not available on riscv64 and s390x, so skip there
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /usr/local/bin
     if [ "$ARCH" = "x86_64" ]; then
         curl -O https://uploader.codecov.io/latest/linux/codecov
@@ -106,9 +114,9 @@ cargo install cargo-all-features
 
 # Install some dependencies required by vhost-device crates but not available
 # in Ubuntu repos.
-# Some of these do not support riscv64, since vhost-device crates do not
-# support riscv64 too, let's skip them for now.
-if [ "$ARCH" != "riscv64" ]; then
+# Some of these do not support riscv64 or s390x, since vhost-device crates do not
+# work on those platforms for now, let's skip them.
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ]; then
     pushd /opt
 
     # required by vhost-device-gpu
@@ -160,9 +168,9 @@ fi
 # dbus-daemon expects this folder
 mkdir -p /run/dbus
 
-# `riscv64` specific, which setup the rootfs for `riscv64` VM to execute actual
-# RISC-V tests through prepared ssh server.
-if [ "$ARCH" == "riscv64" ]; then
+# QEMU specific, which setup the rootfs for `riscv64` and `s390x` VM to execute actual
+# target ARCH tests through prepared ssh server.
+if [ "$ARCH" == "riscv64" ] || [ "$ARCH" == "s390x" ] ; then
     # Set passwd for debugging
     echo 'root:rustvmm' | chpasswd
     # Allow root login
@@ -173,10 +181,14 @@ if [ "$ARCH" == "riscv64" ]; then
     mkdir -p /root/.ssh
     # Setup network
     echo $'auto lo\niface lo inet loopback\n\nauto eth0\niface eth0 inet dhcp\n' > /etc/network/interfaces
+    # `s390x` names the virtio-net interface `enc1` instead of `eth0`
+    if [ "$ARCH" == "s390x" ]; then
+        echo $'\nauto enc1\niface enc1 inet dhcp\n' >> /etc/network/interfaces
+    fi
 fi
 
-# Install kani in x86 and arm. Not available on riscv64, so skip there
-if [ "$ARCH" != "riscv64" ]; then
+# Install kani in x86 and arm. Not available on riscv64 and s390x, so skip there
+if [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "s390x" ] ; then
     cargo install --locked kani-verifier
     cargo kani setup
 fi

--- a/s390x/build_finalize.sh
+++ b/s390x/build_finalize.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -ex
+
+apt-get update
+
+DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    openssh-client libslirp-dev libfdt-dev libglib2.0-dev libssl-dev \
+    libpixman-1-dev qemu-system-s390x
+
+# Modify fstab to mount `tmpfs` during boot
+# See: https://wiki.qemu.org/Documentation/9p_root_fs#Let's_start_the_Installation
+echo 'tmpfs /tmp tmpfs rw,nosuid,nodev,size=524288k,nr_inodes=204800 0 0' >> $ROOTFS_DIR/etc/fstab
+
+# Setup container ssh config
+yes "" | ssh-keygen -P ""
+cat /root/.ssh/*.pub > $ROOTFS_DIR/root/.ssh/authorized_keys
+cat > /root/.ssh/config << EOF
+Host s390x-qemu
+    HostName localhost
+    User root
+    Port 2222
+    StrictHostKeyChecking no
+EOF
+
+# Set `nameserver` to `10.0.2.3` as QEMU User Networking documented.
+# See: https://wiki.qemu.org/Documentation/Networking
+echo 'nameserver 10.0.2.3' > $ROOTFS_DIR/etc/resolv.conf

--- a/s390x/start_in_qemu.sh
+++ b/s390x/start_in_qemu.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -ex
+
+# Minimum resources needed
+MIN_CORES=4
+MIN_MEM=6
+DIVISOR=5
+
+# Try to use 1/${DIVISOR} of resources for qemu-system
+TOTAL_CORES=$(nproc)
+ONE_FIFTH_CORES=$(( TOTAL_CORES / DIVISOR ))
+CORES=$(( ONE_FIFTH_CORES > MIN_CORES ? ONE_FIFTH_CORES : MIN_CORES ))
+
+TOTAL_MEM=$(( $(awk '/MemTotal/ {print $2}' /proc/meminfo) / 1024 / 1024 ))
+ONE_FIFTH_MEM=$(( TOTAL_MEM / DIVISOR ))
+MEM=$(( ONE_FIFTH_MEM > MIN_MEM ? ONE_FIFTH_MEM : MIN_MEM ))G
+
+qemu-system-s390x \
+    -M s390-ccw-virtio \
+    -cpu qemu \
+    -nographic \
+    -smp $CORES -m $MEM \
+    -fsdev local,path=$ROOTFS_DIR,security_model=none,id=rootfs \
+    -device virtio-9p-ccw,fsdev=rootfs,mount_tag=rootfs \
+    -device virtio-net-ccw,netdev=usernet \
+    -netdev user,id=usernet,hostfwd=tcp::2222-:22 \
+    -kernel $ROOTFS_DIR/boot/vmlinuz \
+    -initrd $ROOTFS_DIR/boot/initrd.img \
+    -append "root=rootfs rw rootfstype=9p rootflags=trans=virtio,cache=mmap,msize=512000 console=ttyS0 nokaslr" 2>&1 &
+
+# Copy WORKDIR to ROOTFS_DIR
+cp -a $WORKDIR $ROOTFS_DIR/root
+
+HOST=s390x-qemu
+
+echo "Testing SSH connectivity to $HOST..."
+while ! ssh -o ConnectTimeout=1 -q $HOST exit; do
+  sleep 10s
+  echo "$HOST is not ready..."
+done
+
+# Issue command
+COMMAND=$@
+echo "$HOST is ready, forwarding command: $COMMAND"
+ssh $HOST "export PATH=\"\$PATH:/root/.cargo/bin\" && cd workdir && $COMMAND"


### PR DESCRIPTION
### Summary of the PR

[I would like to use seccompiler on s390x.](https://github.com/rust-vmm/seccompiler/pull/97)

To get the CI running a new dev image is needed just like for riscv. 
I copied the riscv setup and striped it down for s390x. This are my changes:
- use vanilla kernel instead of custom build
- use vanilla qemu instead of custom build
- use initrd to get 9p boot running.
- no riscv specific drivers

Conceptually its the same as the riscv image:
- create a s390x dev image (*rootfs_builder*)
- install all dev dependencies
- create a native dev image
- copy (*rootfs_builder*) into the native image at /opt/rootfs
- setup auto boot of the newly created rootfs via qemu-system-s390x in container entrypoint

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
