### PR TITLE
build_container: add vhost-device-media dependencies

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -15,7 +15,9 @@ DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     build-essential libjsoncpp25 librhash0 make \
     autoconf autoconf-archive automake libtool \
     libclang-dev iproute2 \
+    linux-libc-dev \
     libasound2t64 libasound2-dev \
+    libavcodec-dev libavutil-dev \
     libepoxy0 libepoxy-dev \
     libdrm2 libdrm-dev \
     libgbm1 libgbm-dev libgles2 \


### PR DESCRIPTION
Add linux-libc-dev and FFmpeg development libraries required by the vhost-device-media crate:

- linux-libc-dev: provides sys/time.h needed by v4l2r's bindgen when processing videodev2.h. While libc6-dev is already installed, clang (used by bindgen) may not find the headers without this package.

- libavcodec-dev, libavutil-dev: needed by the virtio-media ffmpeg-decoder backend.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
