### PR TITLE
chore: update rust toolchain to 1.96.0

### DIFF
--- a/docker.env
+++ b/docker.env
@@ -2,4 +2,4 @@ IMAGE_NAME=rustvmm/dev
 REGISTRY=index.docker.io
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-RUST_TOOLCHAIN="1.90.0"
+RUST_TOOLCHAIN="1.96.0"


### PR DESCRIPTION
### Summary of the PR

Bump the pinned Rust toolchain used by the rustvmm/dev container from 1.90.0 to 1.96.0.

building `main` branch currently fails due to unsatisfied requirement to at least rust 1.96.0 from a dependency.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test. 
  - **NO**
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
  - **NO** Changelog
- [ ] Any newly added `unsafe` code is properly documented.
  - **NO** unsafe code
